### PR TITLE
fix(arc-fitter): collapse multi-line #[error] to pass rustfmt check

### DIFF
--- a/src/arc_fitter.rs
+++ b/src/arc_fitter.rs
@@ -33,9 +33,7 @@ use crate::models::{GCodeCommand, Spanned};
 #[derive(Debug, thiserror::Error)]
 pub enum ArcFitConfigError {
     /// `tolerance_mm` must be strictly positive and finite.
-    #[error(
-        "ArcFitConfig: tolerance_mm must be positive and finite, got {value}"
-    )]
+    #[error("ArcFitConfig: tolerance_mm must be positive and finite, got {value}")]
     InvalidTolerance {
         /// The invalid value that was provided.
         value: f64,


### PR DESCRIPTION
## Summary

- One-line change: collapse the multi-line `#[error(...)]` attribute on `ArcFitConfigError::InvalidTolerance` to a single line, which is what `rustfmt` requires.

## Root cause

The `ArcFitConfigError` enum added in the v2.2 remediation used a multi-line `#[error(...)]` form that locally passes `cargo fmt -- --check` only if the line length threshold is not exceeded. In CI the formatter rejected it.

## Test Plan

- [ ] `cargo fmt -- --check` — clean
- [ ] `cargo test` — 178 unit + 23 integration + 2 doc tests passing