### PR TITLE
fix(ci): apply rustfmt formatting to ArcFitConfigError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "gcode-sentinel"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "clap",


### PR DESCRIPTION
## Summary
- CI was failing because `ArcFitConfigError` had an error attribute that did not pass `cargo fmt -- --check`
- Applied `cargo fmt` to bring the attribute in line with rustfmt expectations
- Updated `Cargo.lock`

## Test plan
- [ ] `cargo fmt -- --check` passes
- [ ] All existing tests pass (`cargo test`)