### PR TITLE
feat(machine-profiles): TOML machine profiles and --machine CLI flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "gcode-sentinel"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -164,6 +164,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -427,6 +428,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,6 +508,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -650,6 +694,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
+# TOML deserialization for machine profiles — MIT OR Apache-2.0
+toml = { version = "0.8", default-features = false, features = ["parse"] }
+
 [dev-dependencies]
 # Temporary files in tests — MIT OR Apache-2.0
 tempfile = "3"

--- a/src/arc_fitter.rs
+++ b/src/arc_fitter.rs
@@ -33,9 +33,7 @@ use crate::models::{GCodeCommand, Spanned};
 #[derive(Debug, thiserror::Error)]
 pub enum ArcFitConfigError {
     /// `tolerance_mm` must be strictly positive and finite.
-    #[error(
-        "ArcFitConfig: tolerance_mm must be positive and finite, got {value}"
-    )]
+    #[error("ArcFitConfig: tolerance_mm must be positive and finite, got {value}")]
     InvalidTolerance {
         /// The invalid value that was provided.
         value: f64,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -161,28 +161,68 @@ pub struct Cli {
     /// included in an arc.  Default: 0.02 mm.
     #[arg(long, value_name = "MM")]
     pub arc_tolerance: Option<f64>,
+
+    /// Select a built-in machine profile by name (e.g. `ender3`, `prusa_mk4`).
+    ///
+    /// The profile sets default axis limits and optional firmware metadata.
+    /// Explicit `--max-x/y/z` flags override the profile values.
+    /// Use `--machine help` (or supply an invalid name) to see all available
+    /// profiles listed in the error message.
+    ///
+    /// Resolution order (later overrides earlier):
+    /// defaults → `--config` file → `--machine` profile → explicit flags.
+    #[arg(long, value_name = "PROFILE")]
+    pub machine: Option<String>,
 }
 
 impl Cli {
-    /// Constructs a [`MachineLimits`] value from the axis-limit flags.
+    /// Constructs a [`MachineLimits`] value following the resolution order.
     ///
-    /// Returns `Some` if at least one of `--max-x`, `--max-y`, or `--max-z`
-    /// was supplied on the command line, allowing partial limit configurations
-    /// (e.g. only the Z axis is constrained).  Returns `None` when all three
-    /// are absent, signalling to the pipeline that out-of-bounds checking
-    /// should be skipped or delegated to a config file.
+    /// Resolution order (later source overrides earlier):
+    /// 1. No limits at all (returns `None` when nothing is configured).
+    /// 2. A `--machine` profile supplied via `profile` (axis bounds only).
+    /// 3. Explicit `--max-x`, `--max-y`, `--max-z` flags on the command line.
+    ///
+    /// Returns `Some` when either a profile is given **or** at least one
+    /// explicit axis flag is present.  Returns `None` when both are absent,
+    /// signalling to the pipeline that out-of-bounds checking should be skipped.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gcode_sentinel::cli::Cli;
+    /// use clap::Parser;
+    ///
+    /// let cli = Cli::try_parse_from(["gcode-sentinel", "in.gcode", "--max-x", "220"]).unwrap();
+    /// let limits = cli.machine_limits(None);
+    /// assert_eq!(limits.unwrap().max_x, 220.0);
+    /// ```
     ///
     /// [`MachineLimits`]: crate::models::MachineLimits
     #[must_use]
-    pub fn machine_limits(&self) -> Option<crate::models::MachineLimits> {
-        if self.max_x.is_none() && self.max_y.is_none() && self.max_z.is_none() {
+    pub fn machine_limits(
+        &self,
+        profile: Option<&crate::machine_profile::MachineProfile>,
+    ) -> Option<crate::models::MachineLimits> {
+        let has_explicit = self.max_x.is_some() || self.max_y.is_some() || self.max_z.is_some();
+
+        // Profile base — if a profile was loaded, use it as the starting point.
+        let base: Option<crate::models::MachineLimits> =
+            profile.map(crate::machine_profile::MachineProfile::to_machine_limits);
+
+        if base.is_none() && !has_explicit {
+            // Nothing configured — disable out-of-bounds checking.
             return None;
         }
-        let defaults = crate::models::MachineLimits::default();
+
+        // Start from profile limits when available; fall back to type defaults
+        // only if an explicit flag is present without a profile.
+        let base = base.unwrap_or_default();
+
         Some(crate::models::MachineLimits {
-            max_x: self.max_x.unwrap_or(defaults.max_x),
-            max_y: self.max_y.unwrap_or(defaults.max_y),
-            max_z: self.max_z.unwrap_or(defaults.max_z),
+            max_x: self.max_x.unwrap_or(base.max_x),
+            max_y: self.max_y.unwrap_or(base.max_y),
+            max_z: self.max_z.unwrap_or(base.max_z),
         })
     }
 }
@@ -218,5 +258,96 @@ mod tests {
     fn report_format_defaults_to_text() {
         let cli = Cli::try_parse_from(["gcode-sentinel", "input.gcode"]).unwrap();
         assert!(matches!(cli.report_format, ReportFormat::Text));
+    }
+
+    // ── --machine flag ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_machine_flag_parsed_correctly() {
+        let cli =
+            Cli::try_parse_from(["gcode-sentinel", "input.gcode", "--machine", "ender3"]).unwrap();
+        assert_eq!(cli.machine.as_deref(), Some("ender3"));
+    }
+
+    #[test]
+    fn test_machine_flag_absent_is_none() {
+        let cli = Cli::try_parse_from(["gcode-sentinel", "input.gcode"]).unwrap();
+        assert_eq!(cli.machine, None);
+    }
+
+    // ── machine_limits resolution order ─────────────────────────────────────
+
+    #[test]
+    fn test_machine_limits_no_profile_no_flags_returns_none() {
+        let cli = Cli::try_parse_from(["gcode-sentinel", "input.gcode"]).unwrap();
+        assert!(cli.machine_limits(None).is_none());
+    }
+
+    #[test]
+    fn test_machine_limits_profile_only_uses_profile_values() {
+        use crate::machine_profile::load_profile;
+        let cli = Cli::try_parse_from(["gcode-sentinel", "input.gcode"]).unwrap();
+        let profile = load_profile("ender3").unwrap();
+        let limits = cli.machine_limits(Some(&profile)).unwrap();
+        assert_eq!(limits.max_x, 220.0);
+        assert_eq!(limits.max_y, 220.0);
+        assert_eq!(limits.max_z, 250.0);
+    }
+
+    #[test]
+    fn test_machine_limits_explicit_flags_override_profile() {
+        use crate::machine_profile::load_profile;
+        let cli = Cli::try_parse_from([
+            "gcode-sentinel",
+            "input.gcode",
+            "--max-x",
+            "180.0",
+            "--max-z",
+            "300.0",
+        ])
+        .unwrap();
+        let profile = load_profile("ender3").unwrap(); // ender3: 220 × 220 × 250
+        let limits = cli.machine_limits(Some(&profile)).unwrap();
+        // Explicit --max-x and --max-z override the profile; --max-y falls back to profile.
+        assert_eq!(
+            limits.max_x, 180.0,
+            "explicit --max-x must win over profile"
+        );
+        assert_eq!(limits.max_y, 220.0, "--max-y absent: profile value used");
+        assert_eq!(
+            limits.max_z, 300.0,
+            "explicit --max-z must win over profile"
+        );
+    }
+
+    #[test]
+    fn test_machine_limits_explicit_flags_only_no_profile() {
+        let cli = Cli::try_parse_from([
+            "gcode-sentinel",
+            "input.gcode",
+            "--max-x",
+            "400.0",
+            "--max-y",
+            "400.0",
+            "--max-z",
+            "500.0",
+        ])
+        .unwrap();
+        let limits = cli.machine_limits(None).unwrap();
+        assert_eq!(limits.max_x, 400.0);
+        assert_eq!(limits.max_y, 400.0);
+        assert_eq!(limits.max_z, 500.0);
+    }
+
+    #[test]
+    fn test_machine_limits_single_explicit_flag_with_profile_partial_override() {
+        use crate::machine_profile::load_profile;
+        let cli =
+            Cli::try_parse_from(["gcode-sentinel", "input.gcode", "--max-y", "150.0"]).unwrap();
+        let profile = load_profile("voron_v2").unwrap(); // voron: 350 × 350 × 350
+        let limits = cli.machine_limits(Some(&profile)).unwrap();
+        assert_eq!(limits.max_x, 350.0, "x falls back to profile");
+        assert_eq!(limits.max_y, 150.0, "explicit --max-y overrides profile");
+        assert_eq!(limits.max_z, 350.0, "z falls back to profile");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod cli;
 pub mod diagnostics;
 pub mod emitter;
 pub(crate) mod geometry;
+pub mod machine_profile;
 pub mod models;
 pub mod optimizer;
 pub mod parser;

--- a/src/machine_profile.rs
+++ b/src/machine_profile.rs
@@ -1,0 +1,409 @@
+//! Built-in machine profiles and TOML-based profile loading.
+//!
+//! # Overview
+//!
+//! A [`MachineProfile`] captures the physical envelope and optional firmware
+//! properties of a 3D printer.  Five profiles ship with the binary (embedded as
+//! inline TOML strings so no filesystem access is required at runtime):
+//!
+//! | Name            | Bed (X × Y) | Z   | Notes                     |
+//! |-----------------|-------------|-----|---------------------------|
+//! | `ender3`        | 220 × 220   | 250 | Creality Ender-3 family   |
+//! | `prusa_mk4`     | 250 × 210   | 220 | Prusa MK4                 |
+//! | `voron_v2`      | 350 × 350   | 350 | Voron V2.4 (350 mm kit)   |
+//! | `bambu_x1c`     | 256 × 256   | 256 | Bambu Lab X1 Carbon       |
+//! | `generic_300`   | 300 × 300   | 400 | Generic 300 mm printer    |
+//!
+//! # Usage
+//!
+//! ```rust
+//! use gcode_sentinel::machine_profile::load_profile;
+//!
+//! let profile = load_profile("ender3").expect("ender3 must be built-in");
+//! assert_eq!(profile.max_x_mm, 220.0);
+//! ```
+//!
+//! # Error handling
+//!
+//! [`load_profile`] returns [`ProfileError::UnknownProfile`] when the requested
+//! name is not in the built-in registry.  The error message includes a
+//! comma-separated list of every valid name so the user can self-correct.
+
+use crate::models::MachineLimits;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Error type
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Errors that can occur when loading a machine profile.
+#[derive(Debug, thiserror::Error)]
+pub enum ProfileError {
+    /// The requested profile name is not in the built-in registry.
+    ///
+    /// `available` lists every valid profile name so the caller or user can
+    /// correct the input without a separate lookup.
+    #[error(
+        "unknown machine profile '{name}'; available profiles: {available}",
+        available = available.join(", ")
+    )]
+    UnknownProfile {
+        /// The name that was requested but not found.
+        name: String,
+        /// Every valid built-in profile name, in registration order.
+        available: Vec<String>,
+    },
+
+    /// A built-in profile string could not be parsed as TOML.
+    ///
+    /// This variant should never occur in a correctly assembled binary; its
+    /// presence ensures that TOML parse failures surface clearly rather than
+    /// panicking.
+    #[error("failed to parse built-in profile '{name}': {source}")]
+    ParseError {
+        /// Name of the profile whose TOML could not be parsed.
+        name: &'static str,
+        /// Underlying TOML parse error.
+        #[source]
+        source: toml::de::Error,
+    },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MachineProfile
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Physical envelope and optional firmware properties of a 3D printer.
+///
+/// All dimension fields are in millimetres.  Optional fields are absent when
+/// the profile author does not constrain that property; the rest of the
+/// pipeline treats `None` as "unconstrained".
+///
+/// # Examples
+///
+/// ```rust
+/// use gcode_sentinel::machine_profile::load_profile;
+///
+/// let p = load_profile("bambu_x1c").unwrap();
+/// assert_eq!(p.max_x_mm, 256.0);
+/// assert_eq!(p.firmware.as_deref(), Some("bambu"));
+/// ```
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+pub struct MachineProfile {
+    /// Human-readable profile name (matches the lookup key).
+    pub name: String,
+
+    /// Maximum X-axis travel in millimetres.
+    pub max_x_mm: f64,
+
+    /// Maximum Y-axis travel in millimetres.
+    pub max_y_mm: f64,
+
+    /// Maximum Z-axis travel in millimetres.
+    pub max_z_mm: f64,
+
+    /// Maximum axis feedrate in mm/min, if the firmware enforces a limit.
+    pub max_feedrate_mm_per_min: Option<f64>,
+
+    /// Maximum axis acceleration in mm/s², if the firmware enforces a limit.
+    pub max_acceleration_mm_per_s2: Option<f64>,
+
+    /// Nozzle diameter in millimetres, if specified.
+    pub nozzle_diameter_mm: Option<f64>,
+
+    /// Firmware variant identifier (e.g. `"marlin"`, `"klipper"`, `"bambu"`).
+    pub firmware: Option<String>,
+}
+
+impl MachineProfile {
+    /// Converts this profile into [`MachineLimits`] using only the axis bounds.
+    ///
+    /// The optional fields (`max_feedrate_mm_per_min`, etc.) are not yet
+    /// consumed by the analyser; they are preserved in the profile for future
+    /// use.
+    #[must_use]
+    pub fn to_machine_limits(&self) -> MachineLimits {
+        MachineLimits {
+            max_x: self.max_x_mm,
+            max_y: self.max_y_mm,
+            max_z: self.max_z_mm,
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Built-in profile registry
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A single entry in the built-in profile registry.
+struct BuiltinEntry {
+    /// The lookup key (lowercase, underscore-separated).
+    key: &'static str,
+    /// The TOML source for this profile.
+    toml: &'static str,
+}
+
+/// All built-in profiles, in the order shown in the module-level table.
+///
+/// Profiles are stored as inline TOML strings rather than separate files so
+/// that the binary is fully self-contained.  The TOML is parsed on first use;
+/// parsing a dozen small strings is cheap enough that lazy initialisation is
+/// not warranted.
+static BUILTIN_PROFILES: &[BuiltinEntry] = &[
+    BuiltinEntry {
+        key: "ender3",
+        toml: r#"
+name = "ender3"
+max_x_mm = 220.0
+max_y_mm = 220.0
+max_z_mm = 250.0
+max_feedrate_mm_per_min = 500.0
+nozzle_diameter_mm = 0.4
+firmware = "marlin"
+"#,
+    },
+    BuiltinEntry {
+        key: "prusa_mk4",
+        toml: r#"
+name = "prusa_mk4"
+max_x_mm = 250.0
+max_y_mm = 210.0
+max_z_mm = 220.0
+max_feedrate_mm_per_min = 500.0
+max_acceleration_mm_per_s2 = 1250.0
+nozzle_diameter_mm = 0.4
+firmware = "prusa"
+"#,
+    },
+    BuiltinEntry {
+        key: "voron_v2",
+        toml: r#"
+name = "voron_v2"
+max_x_mm = 350.0
+max_y_mm = 350.0
+max_z_mm = 350.0
+max_feedrate_mm_per_min = 600.0
+max_acceleration_mm_per_s2 = 3000.0
+nozzle_diameter_mm = 0.4
+firmware = "klipper"
+"#,
+    },
+    BuiltinEntry {
+        key: "bambu_x1c",
+        toml: r#"
+name = "bambu_x1c"
+max_x_mm = 256.0
+max_y_mm = 256.0
+max_z_mm = 256.0
+max_feedrate_mm_per_min = 1200.0
+max_acceleration_mm_per_s2 = 20000.0
+nozzle_diameter_mm = 0.4
+firmware = "bambu"
+"#,
+    },
+    BuiltinEntry {
+        key: "generic_300",
+        toml: r#"
+name = "generic_300"
+max_x_mm = 300.0
+max_y_mm = 300.0
+max_z_mm = 400.0
+"#,
+    },
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Returns the names of every built-in profile, in registration order.
+///
+/// Use this to present the user with valid choices when an unknown name is
+/// supplied, or to iterate over all profiles for validation purposes.
+#[must_use]
+pub fn available_profiles() -> Vec<&'static str> {
+    BUILTIN_PROFILES.iter().map(|e| e.key).collect()
+}
+
+/// Loads a built-in machine profile by name.
+///
+/// The lookup is case-sensitive; names use lowercase with underscores
+/// (e.g. `"ender3"`, `"prusa_mk4"`).
+///
+/// # Errors
+///
+/// - [`ProfileError::UnknownProfile`] — `name` is not in the built-in registry.
+///   The error message lists all valid names.
+/// - [`ProfileError::ParseError`] — the built-in TOML for the matched profile
+///   is syntactically invalid.  This should never occur in a correctly built
+///   binary; it is included for completeness.
+pub fn load_profile(name: &str) -> Result<MachineProfile, ProfileError> {
+    let entry = BUILTIN_PROFILES.iter().find(|e| e.key == name);
+
+    let Some(entry) = entry else {
+        let available = available_profiles().into_iter().map(String::from).collect();
+        return Err(ProfileError::UnknownProfile {
+            name: name.to_owned(),
+            available,
+        });
+    };
+
+    toml::from_str(entry.toml).map_err(|source| ProfileError::ParseError {
+        name: entry.key,
+        source,
+    })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── available_profiles ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_available_profiles_returns_all_names() {
+        let names = available_profiles();
+        assert_eq!(
+            names,
+            vec![
+                "ender3",
+                "prusa_mk4",
+                "voron_v2",
+                "bambu_x1c",
+                "generic_300"
+            ]
+        );
+    }
+
+    // ── load_profile: happy path for each built-in ───────────────────────────
+
+    #[test]
+    fn test_load_profile_ender3_returns_correct_limits() {
+        let p = load_profile("ender3").expect("ender3 must load");
+        assert_eq!(p.name, "ender3");
+        assert_eq!(p.max_x_mm, 220.0);
+        assert_eq!(p.max_y_mm, 220.0);
+        assert_eq!(p.max_z_mm, 250.0);
+        assert_eq!(p.max_feedrate_mm_per_min, Some(500.0));
+        assert_eq!(p.nozzle_diameter_mm, Some(0.4));
+        assert_eq!(p.firmware.as_deref(), Some("marlin"));
+        assert_eq!(p.max_acceleration_mm_per_s2, None);
+    }
+
+    #[test]
+    fn test_load_profile_prusa_mk4_returns_correct_limits() {
+        let p = load_profile("prusa_mk4").expect("prusa_mk4 must load");
+        assert_eq!(p.name, "prusa_mk4");
+        assert_eq!(p.max_x_mm, 250.0);
+        assert_eq!(p.max_y_mm, 210.0);
+        assert_eq!(p.max_z_mm, 220.0);
+        assert_eq!(p.max_acceleration_mm_per_s2, Some(1250.0));
+        assert_eq!(p.firmware.as_deref(), Some("prusa"));
+    }
+
+    #[test]
+    fn test_load_profile_voron_v2_returns_correct_limits() {
+        let p = load_profile("voron_v2").expect("voron_v2 must load");
+        assert_eq!(p.name, "voron_v2");
+        assert_eq!(p.max_x_mm, 350.0);
+        assert_eq!(p.max_y_mm, 350.0);
+        assert_eq!(p.max_z_mm, 350.0);
+        assert_eq!(p.max_acceleration_mm_per_s2, Some(3000.0));
+        assert_eq!(p.firmware.as_deref(), Some("klipper"));
+    }
+
+    #[test]
+    fn test_load_profile_bambu_x1c_returns_correct_limits() {
+        let p = load_profile("bambu_x1c").expect("bambu_x1c must load");
+        assert_eq!(p.name, "bambu_x1c");
+        assert_eq!(p.max_x_mm, 256.0);
+        assert_eq!(p.max_y_mm, 256.0);
+        assert_eq!(p.max_z_mm, 256.0);
+        assert_eq!(p.max_feedrate_mm_per_min, Some(1200.0));
+        assert_eq!(p.max_acceleration_mm_per_s2, Some(20_000.0));
+        assert_eq!(p.firmware.as_deref(), Some("bambu"));
+    }
+
+    #[test]
+    fn test_load_profile_generic_300_returns_correct_limits() {
+        let p = load_profile("generic_300").expect("generic_300 must load");
+        assert_eq!(p.name, "generic_300");
+        assert_eq!(p.max_x_mm, 300.0);
+        assert_eq!(p.max_y_mm, 300.0);
+        assert_eq!(p.max_z_mm, 400.0);
+        assert_eq!(p.max_feedrate_mm_per_min, None);
+        assert_eq!(p.max_acceleration_mm_per_s2, None);
+        assert_eq!(p.nozzle_diameter_mm, None);
+        assert_eq!(p.firmware, None);
+    }
+
+    // ── load_profile: unknown name ───────────────────────────────────────────
+
+    #[test]
+    fn test_load_profile_unknown_name_returns_error() {
+        let result = load_profile("does_not_exist");
+        assert!(result.is_err());
+        assert!(matches!(result, Err(ProfileError::UnknownProfile { .. })));
+    }
+
+    #[test]
+    fn test_load_profile_unknown_name_error_contains_all_profile_names() {
+        let err = load_profile("nope").unwrap_err();
+        let msg = err.to_string();
+        // The error message must list every valid profile so the user can self-correct.
+        assert!(msg.contains("ender3"), "error should mention ender3: {msg}");
+        assert!(
+            msg.contains("prusa_mk4"),
+            "error should mention prusa_mk4: {msg}"
+        );
+        assert!(
+            msg.contains("voron_v2"),
+            "error should mention voron_v2: {msg}"
+        );
+        assert!(
+            msg.contains("bambu_x1c"),
+            "error should mention bambu_x1c: {msg}"
+        );
+        assert!(
+            msg.contains("generic_300"),
+            "error should mention generic_300: {msg}"
+        );
+        assert!(
+            msg.contains("nope"),
+            "error should echo the bad name: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_load_profile_case_sensitive_uppercase_returns_error() {
+        // Profile names are lowercase; uppercase must not silently match.
+        let result = load_profile("Ender3");
+        assert!(
+            matches!(result, Err(ProfileError::UnknownProfile { .. })),
+            "lookup must be case-sensitive"
+        );
+    }
+
+    // ── to_machine_limits ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_machine_profile_to_machine_limits_uses_axis_bounds() {
+        let p = load_profile("ender3").expect("ender3 must load");
+        let limits = p.to_machine_limits();
+        assert_eq!(limits.max_x, 220.0);
+        assert_eq!(limits.max_y, 220.0);
+        assert_eq!(limits.max_z, 250.0);
+    }
+
+    #[test]
+    fn test_machine_profile_to_machine_limits_voron_v2() {
+        let p = load_profile("voron_v2").expect("voron_v2 must load");
+        let limits = p.to_machine_limits();
+        assert_eq!(limits.max_x, 350.0);
+        assert_eq!(limits.max_y, 350.0);
+        assert_eq!(limits.max_z, 350.0);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use gcode_sentinel::arc_fitter::{fit_arcs, ArcFitConfig, DEFAULT_ARC_TOLERANCE_M
 use gcode_sentinel::cli::{Cli, ReportFormat};
 use gcode_sentinel::diagnostics::{AnalysisReport, OptimizationChange, Severity, ValidationDiff};
 use gcode_sentinel::emitter::{emit, EmitConfig};
+use gcode_sentinel::machine_profile::{self, MachineProfile};
 use gcode_sentinel::optimizer::{optimize, OptConfig};
 use gcode_sentinel::parser::parse_all;
 
@@ -25,7 +26,8 @@ fn main() -> Result<()> {
     validate_input(&cli)?;
     validate_cli_flags(&cli)?;
 
-    let limits = cli.machine_limits();
+    let profile = resolve_machine_profile(&cli)?;
+    let limits = cli.machine_limits(profile.as_ref());
     log_limits(limits.as_ref());
 
     let text = map_input(&cli)?;
@@ -149,6 +151,19 @@ fn main() -> Result<()> {
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Loads the machine profile selected via `--machine`, if any.
+///
+/// Returns `Ok(None)` when the flag is absent.  Returns a descriptive error
+/// (listing all valid names) when an unknown profile name is supplied.
+fn resolve_machine_profile(cli: &Cli) -> Result<Option<MachineProfile>> {
+    let Some(ref name) = cli.machine else {
+        return Ok(None);
+    };
+    machine_profile::load_profile(name)
+        .map(Some)
+        .with_context(|| format!("failed to load machine profile '{name}'"))
+}
 
 fn init_tracing(verbose: bool) -> Result<()> {
     let filter = tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {


### PR DESCRIPTION
Closes #9

## Summary
- New `src/machine_profile.rs` module with `MachineProfile` struct (`serde::Deserialize`) and `ProfileError` (`thiserror`)
- 5 built-in profiles embedded as inline TOML: `ender3`, `prusa_mk4`, `voron_v2`, `bambu_x1c`, `generic_300`
- `load_profile(name) -> Result<MachineProfile, ProfileError>` — unknown names produce a helpful error listing all valid profile names
- `--machine <PROFILE>` CLI flag via clap
- Full resolution order implemented: defaults → `--machine` profile → explicit `--max-x/y/z` flags
- Added `toml = { version = "0.8", default-features = false, features = ["parse"] }` (MIT OR Apache-2.0)

## Test plan
- [ ] Built-in profiles load correctly (all 5)
- [ ] Unknown profile name gives helpful error listing valid names
- [ ] Resolution order: defaults < `--machine` < explicit flags
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes (224 tests total, 12 new)