### PR TITLE
feat: slicer dialect detection, fuzz testing, and proptest

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,42 @@
+name: Fuzz
+
+on:
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fuzz:
+    name: Fuzz ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - fuzz_parse
+          - fuzz_round_trip
+          - fuzz_optimize
+          - fuzz_detect_dialect
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust nightly
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz
+
+      - name: Cache fuzz corpus
+        uses: actions/cache@v4
+        with:
+          path: fuzz/corpus/${{ matrix.target }}
+          key: fuzz-corpus-${{ matrix.target }}-${{ github.sha }}
+          restore-keys: |
+            fuzz-corpus-${{ matrix.target }}-
+
+      - name: Run fuzzer
+        run: cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=60

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +169,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +187,7 @@ dependencies = [
  "anyhow",
  "clap",
  "memmap2",
+ "proptest",
  "serde",
  "serde_json",
  "tempfile",
@@ -171,13 +199,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -297,6 +337,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,6 +362,15 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -334,6 +392,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,9 +427,53 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "regex-automata"
@@ -376,6 +503,18 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -475,7 +614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -606,6 +745,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,6 +773,15 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasip2"
@@ -791,6 +945,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ toml = { version = "0.8", default-features = false, features = ["parse"] }
 [dev-dependencies]
 # Temporary files in tests — MIT OR Apache-2.0
 tempfile = "3"
+# Property-based testing — MIT OR Apache-2.0
+proptest = "1"
 
 [profile.release]
 opt-level = 3

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "gcode-sentinel-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+arbitrary = { version = "1", features = ["derive"] }
+gcode-sentinel = { path = ".." }
+
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_parse"
+path = "fuzz_targets/fuzz_parse.rs"
+doc = false
+
+[[bin]]
+name = "fuzz_round_trip"
+path = "fuzz_targets/fuzz_round_trip.rs"
+doc = false
+
+[[bin]]
+name = "fuzz_optimize"
+path = "fuzz_targets/fuzz_optimize.rs"
+doc = false
+
+[[bin]]
+name = "fuzz_detect_dialect"
+path = "fuzz_targets/fuzz_detect_dialect.rs"
+doc = false

--- a/fuzz/fuzz_targets/fuzz_detect_dialect.rs
+++ b/fuzz/fuzz_targets/fuzz_detect_dialect.rs
@@ -1,0 +1,17 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use gcode_sentinel::dialect::{detect_dialect, Confidence};
+use gcode_sentinel::parser::parse_all;
+
+fuzz_target!(|data: &[u8]| {
+    let text = match std::str::from_utf8(data) {
+        Ok(t) => t,
+        Err(_) => return,
+    };
+    let cmds = match parse_all(text) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+    let result = detect_dialect(&cmds, None);
+    assert!(result.metadata.confidence <= Confidence::High);
+});

--- a/fuzz/fuzz_targets/fuzz_detect_dialect.rs
+++ b/fuzz/fuzz_targets/fuzz_detect_dialect.rs
@@ -1,6 +1,6 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use gcode_sentinel::dialect::{detect_dialect, Confidence};
+use gcode_sentinel::dialect::{detect_dialect, Confidence, SlicerDialect};
 use gcode_sentinel::parser::parse_all;
 
 fuzz_target!(|data: &[u8]| {
@@ -14,4 +14,20 @@ fuzz_target!(|data: &[u8]| {
     };
     let result = detect_dialect(&cmds, None);
     assert!(result.metadata.confidence <= Confidence::High);
+
+    // Unknown dialect must have None confidence, and vice versa
+    if result.metadata.dialect == SlicerDialect::Unknown {
+        assert_eq!(
+            result.metadata.confidence,
+            Confidence::None,
+            "Unknown dialect must have None confidence"
+        );
+    }
+    if result.metadata.confidence == Confidence::None {
+        assert_eq!(
+            result.metadata.dialect,
+            SlicerDialect::Unknown,
+            "None confidence must have Unknown dialect"
+        );
+    }
 });

--- a/fuzz/fuzz_targets/fuzz_optimize.rs
+++ b/fuzz/fuzz_targets/fuzz_optimize.rs
@@ -1,0 +1,26 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use gcode_sentinel::analyzer::analyze;
+use gcode_sentinel::optimizer::{optimize, OptConfig};
+use gcode_sentinel::parser::parse_all;
+
+fuzz_target!(|data: &[u8]| {
+    let text = match std::str::from_utf8(data) {
+        Ok(t) => t,
+        Err(_) => return,
+    };
+    let cmds = match parse_all(text) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+    let pre_stats = analyze(cmds.iter(), None).stats;
+    let config = OptConfig::default();
+    let result = optimize(cmds, &config);
+    let post_stats = analyze(result.commands.iter(), None).stats;
+    let diff = (pre_stats.total_filament_mm - post_stats.total_filament_mm).abs();
+    assert!(
+        diff < 1e-6,
+        "Filament not conserved: {:.6} -> {:.6} (diff {diff})",
+        pre_stats.total_filament_mm, post_stats.total_filament_mm
+    );
+});

--- a/fuzz/fuzz_targets/fuzz_parse.rs
+++ b/fuzz/fuzz_targets/fuzz_parse.rs
@@ -1,0 +1,8 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(text) = std::str::from_utf8(data) {
+        let _ = gcode_sentinel::parser::parse_all(text);
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_round_trip.rs
+++ b/fuzz/fuzz_targets/fuzz_round_trip.rs
@@ -1,0 +1,69 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use gcode_sentinel::emitter::{emit, EmitConfig};
+use gcode_sentinel::models::GCodeCommand;
+use gcode_sentinel::parser::parse_all;
+
+fuzz_target!(|data: &[u8]| {
+    let text = match std::str::from_utf8(data) {
+        Ok(t) => t,
+        Err(_) => return,
+    };
+    let cmds = match parse_all(text) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+    let mut buf = Vec::new();
+    if emit(&cmds, &mut buf, &EmitConfig::default()).is_err() {
+        return;
+    }
+    let text2 = match String::from_utf8(buf) {
+        Ok(t) => t,
+        Err(_) => return,
+    };
+    let cmds2 = match parse_all(&text2) {
+        Ok(c) => c,
+        Err(_) => panic!("re-parse failed on emitted output"),
+    };
+    assert_eq!(cmds.len(), cmds2.len(), "command count changed after round-trip");
+    for (a, b) in cmds.iter().zip(cmds2.iter()) {
+        assert!(
+            commands_semantically_equal(&a.inner, &b.inner),
+            "semantic mismatch at line {}: {:?} vs {:?}", a.line, a.inner, b.inner
+        );
+    }
+});
+
+fn commands_semantically_equal(a: &GCodeCommand<'_>, b: &GCodeCommand<'_>) -> bool {
+    use GCodeCommand::*;
+    match (a, b) {
+        (RapidMove { x: x1, y: y1, z: z1, f: f1 }, RapidMove { x: x2, y: y2, z: z2, f: f2 }) =>
+            opts_eq(*x1, *x2) && opts_eq(*y1, *y2) && opts_eq(*z1, *z2) && opts_eq(*f1, *f2),
+        (LinearMove { x: x1, y: y1, z: z1, e: e1, f: f1 }, LinearMove { x: x2, y: y2, z: z2, e: e2, f: f2 }) =>
+            opts_eq(*x1, *x2) && opts_eq(*y1, *y2) && opts_eq(*z1, *z2) && opts_eq(*e1, *e2) && opts_eq(*f1, *f2),
+        (SetAbsolute, SetAbsolute) | (SetRelative, SetRelative) => true,
+        (SetPosition { x: x1, y: y1, z: z1, e: e1 }, SetPosition { x: x2, y: y2, z: z2, e: e2 }) =>
+            opts_eq(*x1, *x2) && opts_eq(*y1, *y2) && opts_eq(*z1, *z2) && opts_eq(*e1, *e2),
+        (MetaCommand { code: c1, .. }, MetaCommand { code: c2, .. }) => c1 == c2,
+        (Comment { .. }, Comment { .. }) => true,
+        (GCommand { code: c1, .. }, GCommand { code: c2, .. }) => c1 == c2,
+        (Unknown { .. }, Unknown { .. }) => true,
+        (ArcMoveCW { x: x1, y: y1, z: z1, e: e1, f: f1, i: i1, j: j1 },
+         ArcMoveCW { x: x2, y: y2, z: z2, e: e2, f: f2, i: i2, j: j2 }) =>
+            opts_eq(*x1, *x2) && opts_eq(*y1, *y2) && opts_eq(*z1, *z2) &&
+            opts_eq(*e1, *e2) && opts_eq(*f1, *f2) && opts_eq(*i1, *i2) && opts_eq(*j1, *j2),
+        (ArcMoveCCW { x: x1, y: y1, z: z1, e: e1, f: f1, i: i1, j: j1 },
+         ArcMoveCCW { x: x2, y: y2, z: z2, e: e2, f: f2, i: i2, j: j2 }) =>
+            opts_eq(*x1, *x2) && opts_eq(*y1, *y2) && opts_eq(*z1, *z2) &&
+            opts_eq(*e1, *e2) && opts_eq(*f1, *f2) && opts_eq(*i1, *i2) && opts_eq(*j1, *j2),
+        _ => false,
+    }
+}
+
+fn opts_eq(a: Option<f64>, b: Option<f64>) -> bool {
+    match (a, b) {
+        (Some(x), Some(y)) => (x - y).abs() < 1e-4,
+        (None, None) => true,
+        _ => false,
+    }
+}

--- a/fuzz/fuzz_targets/fuzz_round_trip.rs
+++ b/fuzz/fuzz_targets/fuzz_round_trip.rs
@@ -14,9 +14,8 @@ fuzz_target!(|data: &[u8]| {
         Err(_) => return,
     };
     let mut buf = Vec::new();
-    if emit(&cmds, &mut buf, &EmitConfig::default()).is_err() {
-        return;
-    }
+    emit(&cmds, &mut buf, &EmitConfig::default())
+        .expect("emit to Vec<u8> should not fail");
     let text2 = match String::from_utf8(buf) {
         Ok(t) => t,
         Err(_) => return,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,6 +9,25 @@ use std::path::PathBuf;
 use clap::Parser;
 use clap::ValueEnum;
 
+/// Slicer dialect for `--dialect` override.
+#[derive(Debug, Clone, Copy, PartialEq, ValueEnum)]
+pub enum CliDialect {
+    OrcaSlicer,
+    PrusaSlicer,
+    Cura,
+}
+
+impl CliDialect {
+    #[must_use]
+    pub fn to_slicer_dialect(self) -> crate::dialect::SlicerDialect {
+        match self {
+            Self::OrcaSlicer => crate::dialect::SlicerDialect::OrcaSlicer,
+            Self::PrusaSlicer => crate::dialect::SlicerDialect::PrusaSlicer,
+            Self::Cura => crate::dialect::SlicerDialect::Cura,
+        }
+    }
+}
+
 /// Output format for the analysis report written via `--report-file` or to
 /// stdout when used without `--report-file`.
 #[derive(Debug, Clone, Default, PartialEq, ValueEnum)]
@@ -173,6 +192,10 @@ pub struct Cli {
     /// defaults → `--config` file → `--machine` profile → explicit flags.
     #[arg(long, value_name = "PROFILE")]
     pub machine: Option<String>,
+
+    /// Override auto-detected slicer dialect.
+    #[arg(long, value_enum, value_name = "DIALECT")]
+    pub dialect: Option<CliDialect>,
 }
 
 impl Cli {

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -164,6 +164,10 @@ pub struct AnalysisReport {
 
     /// Whether this was a dry-run (no output file written).
     pub dry_run: bool,
+
+    /// Slicer dialect and extracted metadata (if detection was run).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slicer: Option<crate::dialect::SlicerMetadata>,
 }
 
 impl AnalysisReport {
@@ -199,6 +203,19 @@ impl AnalysisReport {
         writeln!(writer, "Est. time : {mins:.0} min")?;
         writeln!(writer, "Bbox min  : {}", self.stats.bbox_min)?;
         writeln!(writer, "Bbox max  : {}", self.stats.bbox_max)?;
+
+        if let Some(ref slicer) = self.slicer {
+            if slicer.dialect != crate::dialect::SlicerDialect::Unknown {
+                writeln!(
+                    writer,
+                    "Slicer    : {:?} ({:?})",
+                    slicer.dialect, slicer.confidence
+                )?;
+            }
+            if let Some(ref v) = slicer.slicer_version {
+                writeln!(writer, "Version   : {v}")?;
+            }
+        }
 
         if self.diagnostics.is_empty() {
             writeln!(writer, "\nNo issues found.")?;
@@ -311,6 +328,7 @@ mod tests {
             stats: PrintStats::default(),
             changes: vec![],
             dry_run: false,
+            slicer: None,
         };
         let json = serde_json::to_string(&report).unwrap();
         let val: serde_json::Value = serde_json::from_str(&json).unwrap();

--- a/src/dialect.rs
+++ b/src/dialect.rs
@@ -1,0 +1,756 @@
+//! Slicer dialect detection and metadata extraction.
+//!
+//! Analyses a parsed G-Code command stream to identify which slicer produced it
+//! and extract print-relevant metadata (nozzle diameter, layer height, filament
+//! type, temperatures, estimated print time).
+
+use crate::diagnostics::{Diagnostic, Severity};
+use crate::models::{GCodeCommand, Spanned};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Confidence
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// How confident the detector is in its dialect identification.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
+pub enum Confidence {
+    /// No dialect could be identified.
+    #[default]
+    None,
+    /// A single weak heuristic matched.
+    Low,
+    /// Multiple heuristics matched, but no definitive signature.
+    Medium,
+    /// A definitive comment signature was found.
+    High,
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// SlicerDialect
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Known slicer dialects.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub enum SlicerDialect {
+    /// Bambu Lab `OrcaSlicer`.
+    OrcaSlicer,
+    /// Prusa Research `PrusaSlicer`.
+    PrusaSlicer,
+    /// Ultimaker Cura.
+    Cura,
+    /// Dialect could not be determined.
+    Unknown,
+}
+
+impl SlicerDialect {
+    /// Returns the metadata field names expected for this dialect.
+    #[must_use]
+    pub fn expected_fields(self) -> &'static [&'static str] {
+        match self {
+            Self::OrcaSlicer | Self::PrusaSlicer => &[
+                "nozzle_diameter",
+                "layer_height",
+                "filament_type",
+                "first_layer_bed_temperature",
+                "nozzle_temperature",
+                "estimated_printing_time",
+            ],
+            Self::Cura => &[
+                "nozzle_diameter",
+                "layer_height",
+                "filament_type",
+                "bed_temperature",
+                "nozzle_temperature",
+                "print_time",
+            ],
+            Self::Unknown => &[],
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// SlicerMetadata
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Extracted slicer metadata from G-Code comments.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
+pub struct SlicerMetadata {
+    /// Detected slicer dialect.
+    pub dialect: Option<SlicerDialect>,
+    /// Detection confidence level.
+    pub confidence: Confidence,
+    /// Slicer version string, if found.
+    pub slicer_version: Option<String>,
+    /// Nozzle diameter in mm (as string, e.g. `"0.4"`).
+    pub nozzle_diameter: Option<String>,
+    /// Layer height in mm (as string, e.g. `"0.2"`).
+    pub layer_height: Option<String>,
+    /// Filament type (e.g. `"PLA"`, `"PETG"`).
+    pub filament_type: Option<String>,
+    /// Bed temperature for the first layer (as string, e.g. `"55"`).
+    pub bed_temperature: Option<String>,
+    /// Nozzle / hotend temperature (as string, e.g. `"210"`).
+    pub nozzle_temperature: Option<String>,
+    /// Estimated print time (raw string from slicer).
+    pub estimated_print_time: Option<String>,
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// DialectResult
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Result of dialect detection: metadata plus any diagnostics generated.
+#[derive(Debug, Clone)]
+pub struct DialectResult {
+    /// Extracted slicer metadata.
+    pub metadata: SlicerMetadata,
+    /// Diagnostics generated during detection.
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Detection
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Detect the slicer dialect and extract metadata from a parsed command stream.
+///
+/// When `dialect_override` is `Some`, it is used directly (with `High` confidence)
+/// and missing-metadata warnings (W005) are suppressed.
+#[must_use]
+pub fn detect_dialect(
+    commands: &[Spanned<GCodeCommand<'_>>],
+    dialect_override: Option<SlicerDialect>,
+) -> DialectResult {
+    let mut metadata = SlicerMetadata::default();
+    let mut diagnostics = Vec::new();
+
+    // Phase 1: Comment signature scan (first 100 lines)
+    let head_limit = commands.len().min(100);
+    let mut phase1_dialect: Option<SlicerDialect> = None;
+    let mut phase1_line: u32 = 0;
+
+    if dialect_override.is_none() {
+        for cmd in &commands[..head_limit] {
+            if let GCodeCommand::Comment { text } = &cmd.inner {
+                let lower = text.to_lowercase();
+                if lower.contains("generated by orcaslicer") {
+                    phase1_dialect = Some(SlicerDialect::OrcaSlicer);
+                    phase1_line = cmd.line;
+                    metadata.slicer_version = extract_version_after(text, "OrcaSlicer");
+                    break;
+                } else if lower.contains("generated by prusaslicer") {
+                    phase1_dialect = Some(SlicerDialect::PrusaSlicer);
+                    phase1_line = cmd.line;
+                    metadata.slicer_version = extract_version_after(text, "PrusaSlicer");
+                    break;
+                } else if lower.contains("flavor:") || lower.contains("generated with cura") {
+                    phase1_dialect = Some(SlicerDialect::Cura);
+                    phase1_line = cmd.line;
+                    if lower.contains("generated with cura") {
+                        metadata.slicer_version = extract_version_after(text, "Cura_SteamEngine");
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    let (dialect, confidence) = if let Some(ovr) = dialect_override {
+        (ovr, Confidence::High)
+    } else if let Some(d) = phase1_dialect {
+        (d, Confidence::High)
+    } else {
+        // Phase 2: M-code heuristics
+        heuristic_detection(commands)
+    };
+
+    metadata.dialect = Some(dialect);
+    metadata.confidence = confidence;
+
+    // Extract metadata based on dialect
+    extract_metadata(commands, dialect, &mut metadata);
+
+    // Emit I004 diagnostic
+    let detection_line = if dialect_override.is_some() {
+        0
+    } else if phase1_dialect.is_some() {
+        phase1_line
+    } else {
+        0
+    };
+
+    if dialect != SlicerDialect::Unknown {
+        diagnostics.push(Diagnostic {
+            severity: Severity::Info,
+            line: detection_line,
+            code: "I004",
+            message: format!("slicer dialect detected: {dialect:?} (confidence: {confidence:?})",),
+        });
+    }
+
+    // W005: expected metadata missing (suppressed when dialect_override is Some)
+    if dialect_override.is_none() && dialect != SlicerDialect::Unknown {
+        let expected = dialect.expected_fields();
+        let missing = collect_missing_fields(&metadata, expected);
+        for field in missing {
+            diagnostics.push(Diagnostic {
+                severity: Severity::Warning,
+                line: 0,
+                code: "W005",
+                message: format!("expected metadata field missing: {field}"),
+            });
+        }
+    }
+
+    DialectResult {
+        metadata,
+        diagnostics,
+    }
+}
+
+/// Run Phase 2 heuristic detection using M-code patterns.
+fn heuristic_detection(commands: &[Spanned<GCodeCommand<'_>>]) -> (SlicerDialect, Confidence) {
+    let mut orca_prusa_signals: u32 = 0;
+    let mut cura_signals: u32 = 0;
+    let mut prusa_signals: u32 = 0;
+
+    for cmd in commands {
+        match &cmd.inner {
+            GCodeCommand::MetaCommand { code: 73, params } => {
+                if params.contains('R') {
+                    // M73 with P+R → orca/prusa
+                    orca_prusa_signals += 1;
+                } else if params.contains('P') {
+                    // M73 with P only → cura
+                    cura_signals += 1;
+                }
+            }
+            GCodeCommand::MetaCommand { code: 900, .. } => {
+                // M900 (linear advance) → prusa signal
+                prusa_signals += 1;
+            }
+            GCodeCommand::Comment { text } if text.starts_with("TYPE:") => {
+                // ;TYPE: comments → orca/prusa
+                orca_prusa_signals += 1;
+            }
+            _ => {}
+        }
+    }
+
+    // Determine the best-matching dialect
+    let orca_prusa_total = orca_prusa_signals + prusa_signals;
+    let total_signals = orca_prusa_total + cura_signals;
+
+    if total_signals == 0 {
+        return (SlicerDialect::Unknown, Confidence::None);
+    }
+
+    // Pick the dialect with the most signals
+    if cura_signals > orca_prusa_total {
+        let conf = if cura_signals >= 2 {
+            Confidence::Medium
+        } else {
+            Confidence::Low
+        };
+        (SlicerDialect::Cura, conf)
+    } else if prusa_signals > 0 {
+        // Prusa-specific M900 tips the balance
+        let conf = if orca_prusa_total >= 2 {
+            Confidence::Medium
+        } else {
+            Confidence::Low
+        };
+        (SlicerDialect::PrusaSlicer, conf)
+    } else {
+        // orca/prusa signals without prusa-specific → OrcaSlicer
+        let conf = if orca_prusa_signals >= 2 {
+            Confidence::Medium
+        } else {
+            Confidence::Low
+        };
+        (SlicerDialect::OrcaSlicer, conf)
+    }
+}
+
+/// Extract metadata fields from the command stream based on dialect.
+fn extract_metadata(
+    commands: &[Spanned<GCodeCommand<'_>>],
+    dialect: SlicerDialect,
+    metadata: &mut SlicerMetadata,
+) {
+    match dialect {
+        SlicerDialect::OrcaSlicer | SlicerDialect::PrusaSlicer => {
+            // Footer: last 100 lines
+            let start = commands.len().saturating_sub(100);
+            for cmd in &commands[start..] {
+                if let GCodeCommand::Comment { text } = &cmd.inner {
+                    extract_orca_prusa_field(text, metadata);
+                }
+            }
+        }
+        SlicerDialect::Cura => {
+            // Header: first 100 lines
+            let limit = commands.len().min(100);
+            for cmd in &commands[..limit] {
+                if let GCodeCommand::Comment { text } = &cmd.inner {
+                    extract_cura_field(text, metadata);
+                }
+            }
+        }
+        SlicerDialect::Unknown => {}
+    }
+}
+
+/// Extract a single OrcaSlicer/PrusaSlicer metadata field from a comment line.
+///
+/// Expected format: ` key = value` (with leading space after semicolon stripped
+/// by the parser). Uses exact key matching to avoid sub-key collisions.
+fn extract_orca_prusa_field(text: &str, metadata: &mut SlicerMetadata) {
+    let trimmed = text.trim();
+
+    // Split on first '=' only
+    if let Some((key, value)) = trimmed.split_once('=') {
+        let key = key.trim();
+        let value = value.trim();
+
+        match key {
+            "nozzle_diameter" => {
+                metadata.nozzle_diameter = Some(value.to_string());
+            }
+            "layer_height" => {
+                metadata.layer_height = Some(value.to_string());
+            }
+            "filament_type" => {
+                metadata.filament_type = Some(value.to_string());
+            }
+            "first_layer_bed_temperature" => {
+                metadata.bed_temperature = Some(value.to_string());
+            }
+            "nozzle_temperature" => {
+                metadata.nozzle_temperature = Some(value.to_string());
+            }
+            _ => {}
+        }
+    }
+
+    // Estimated printing time has a different format:
+    // "; estimated printing time (normal mode) = 2h 26m 25s"
+    if trimmed.starts_with("estimated printing time") {
+        if let Some((_, value)) = trimmed.split_once('=') {
+            metadata.estimated_print_time = Some(value.trim().to_string());
+        }
+    }
+}
+
+/// Extract a single Cura metadata field from a comment line.
+///
+/// Expected formats:
+/// - `Nozzle size: 0.4`
+/// - `Layer height: 0.2`
+/// - `PRINT.TIME:3600`
+/// - `Filament type: PLA`
+/// - `BUILD_PLATE.INITIAL_TEMPERATURE:60`
+/// - `EXTRUDER.INITIAL_TEMPERATURE:210`
+fn extract_cura_field(text: &str, metadata: &mut SlicerMetadata) {
+    let trimmed = text.trim();
+
+    if let Some(val) = trimmed.strip_prefix("Nozzle size:") {
+        metadata.nozzle_diameter = Some(val.trim().to_string());
+    } else if let Some(val) = trimmed.strip_prefix("Layer height:") {
+        metadata.layer_height = Some(val.trim().to_string());
+    } else if let Some(val) = trimmed.strip_prefix("PRINT.TIME:") {
+        metadata.estimated_print_time = Some(val.trim().to_string());
+    } else if let Some(val) = trimmed.strip_prefix("Filament type:") {
+        metadata.filament_type = Some(val.trim().to_string());
+    } else if let Some(val) = trimmed.strip_prefix("BUILD_PLATE.INITIAL_TEMPERATURE:") {
+        metadata.bed_temperature = Some(val.trim().to_string());
+    } else if let Some(val) = trimmed.strip_prefix("EXTRUDER.INITIAL_TEMPERATURE:") {
+        metadata.nozzle_temperature = Some(val.trim().to_string());
+    }
+}
+
+/// Extract a version number that follows a keyword in a comment.
+fn extract_version_after(text: &str, keyword: &str) -> Option<String> {
+    let idx = text.find(keyword)?;
+    let after = &text[idx + keyword.len()..];
+    let trimmed = after.trim();
+    // Take the first whitespace-delimited token as the version
+    let version = trimmed.split_whitespace().next()?;
+    if version.is_empty() {
+        None
+    } else {
+        Some(version.to_string())
+    }
+}
+
+/// Collect names of expected metadata fields that are missing.
+fn collect_missing_fields(
+    metadata: &SlicerMetadata,
+    expected: &[&'static str],
+) -> Vec<&'static str> {
+    let mut missing = Vec::new();
+    for &field in expected {
+        let present = match field {
+            "nozzle_diameter" => metadata.nozzle_diameter.is_some(),
+            "layer_height" => metadata.layer_height.is_some(),
+            "filament_type" => metadata.filament_type.is_some(),
+            "first_layer_bed_temperature" | "bed_temperature" => metadata.bed_temperature.is_some(),
+            "nozzle_temperature" => metadata.nozzle_temperature.is_some(),
+            "estimated_printing_time" | "print_time" => metadata.estimated_print_time.is_some(),
+            _ => true,
+        };
+        if !present {
+            missing.push(field);
+        }
+    }
+    missing
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::borrow::Cow;
+
+    /// Helper to build a `Spanned<GCodeCommand>` comment at a given line.
+    fn comment(line: u32, text: &str) -> Spanned<GCodeCommand<'_>> {
+        Spanned {
+            inner: GCodeCommand::Comment {
+                text: Cow::Borrowed(text),
+            },
+            line,
+            byte_offset: 0,
+        }
+    }
+
+    /// Helper to build a `Spanned<GCodeCommand>` meta command.
+    fn meta(line: u32, code: u16, params: &str) -> Spanned<GCodeCommand<'_>> {
+        Spanned {
+            inner: GCodeCommand::MetaCommand {
+                code,
+                params: Cow::Borrowed(params),
+            },
+            line,
+            byte_offset: 0,
+        }
+    }
+
+    // ── Confidence ordering ──────────────────────────────────────────────
+
+    #[test]
+    fn given_confidence_enum_when_compared_then_none_is_lowest() {
+        assert!(Confidence::None < Confidence::Low);
+        assert!(Confidence::Low < Confidence::Medium);
+        assert!(Confidence::Medium < Confidence::High);
+    }
+
+    // ── expected_fields ──────────────────────────────────────────────────
+
+    #[test]
+    fn given_orcaslicer_when_expected_fields_then_returns_six_fields() {
+        let fields = SlicerDialect::OrcaSlicer.expected_fields();
+        assert_eq!(fields.len(), 6);
+        assert!(fields.contains(&"nozzle_diameter"));
+        assert!(fields.contains(&"estimated_printing_time"));
+    }
+
+    #[test]
+    fn given_cura_when_expected_fields_then_returns_six_fields() {
+        let fields = SlicerDialect::Cura.expected_fields();
+        assert_eq!(fields.len(), 6);
+        assert!(fields.contains(&"print_time"));
+    }
+
+    #[test]
+    fn given_unknown_when_expected_fields_then_returns_empty() {
+        assert!(SlicerDialect::Unknown.expected_fields().is_empty());
+    }
+
+    // ── Phase 1: comment signature detection ─────────────────────────────
+
+    #[test]
+    fn given_orcaslicer_header_when_detected_then_high_confidence() {
+        let commands = vec![
+            comment(1, " generated by OrcaSlicer 2.1.0 on 2024-01-15"),
+            comment(2, " some other comment"),
+        ];
+        let result = detect_dialect(&commands, None);
+        assert_eq!(result.metadata.dialect, Some(SlicerDialect::OrcaSlicer));
+        assert_eq!(result.metadata.confidence, Confidence::High);
+        assert_eq!(result.metadata.slicer_version.as_deref(), Some("2.1.0"));
+    }
+
+    #[test]
+    fn given_prusaslicer_header_when_detected_then_high_confidence() {
+        let commands = vec![comment(
+            1,
+            " generated by PrusaSlicer 2.7.1+linux on 2024-03-01",
+        )];
+        let result = detect_dialect(&commands, None);
+        assert_eq!(result.metadata.dialect, Some(SlicerDialect::PrusaSlicer));
+        assert_eq!(result.metadata.confidence, Confidence::High);
+        assert_eq!(
+            result.metadata.slicer_version.as_deref(),
+            Some("2.7.1+linux")
+        );
+    }
+
+    #[test]
+    fn given_cura_flavor_comment_when_detected_then_high_confidence() {
+        let commands = vec![comment(1, "FLAVOR:Marlin")];
+        let result = detect_dialect(&commands, None);
+        assert_eq!(result.metadata.dialect, Some(SlicerDialect::Cura));
+        assert_eq!(result.metadata.confidence, Confidence::High);
+    }
+
+    #[test]
+    fn given_cura_generated_with_comment_when_detected_then_extracts_version() {
+        let commands = vec![comment(1, " Generated with Cura_SteamEngine 5.6.0")];
+        let result = detect_dialect(&commands, None);
+        assert_eq!(result.metadata.dialect, Some(SlicerDialect::Cura));
+        assert_eq!(result.metadata.slicer_version.as_deref(), Some("5.6.0"));
+    }
+
+    #[test]
+    fn given_case_insensitive_header_when_detected_then_matches() {
+        let commands = vec![comment(1, " GENERATED BY ORCASLICER 2.0.0")];
+        let result = detect_dialect(&commands, None);
+        assert_eq!(result.metadata.dialect, Some(SlicerDialect::OrcaSlicer));
+        assert_eq!(result.metadata.confidence, Confidence::High);
+    }
+
+    // ── Phase 2: heuristic detection ─────────────────────────────────────
+
+    #[test]
+    fn given_m73_with_p_and_r_when_heuristic_then_orca_signal() {
+        let commands = vec![meta(1, 73, "P50 R30"), meta(2, 73, "P75 R15")];
+        let result = detect_dialect(&commands, None);
+        assert_eq!(result.metadata.dialect, Some(SlicerDialect::OrcaSlicer));
+        assert_eq!(result.metadata.confidence, Confidence::Medium);
+    }
+
+    #[test]
+    fn given_m73_with_p_only_when_heuristic_then_cura_signal() {
+        let commands = vec![meta(1, 73, "P50"), meta(2, 73, "P75")];
+        let result = detect_dialect(&commands, None);
+        assert_eq!(result.metadata.dialect, Some(SlicerDialect::Cura));
+        assert_eq!(result.metadata.confidence, Confidence::Medium);
+    }
+
+    #[test]
+    fn given_m900_when_heuristic_then_prusaslicer_signal() {
+        let commands = vec![meta(1, 900, "K0.04"), comment(2, "TYPE:External perimeter")];
+        let result = detect_dialect(&commands, None);
+        assert_eq!(result.metadata.dialect, Some(SlicerDialect::PrusaSlicer));
+        assert_eq!(result.metadata.confidence, Confidence::Medium);
+    }
+
+    #[test]
+    fn given_single_type_comment_when_heuristic_then_low_confidence() {
+        let commands = vec![comment(1, "TYPE:Infill")];
+        let result = detect_dialect(&commands, None);
+        assert_eq!(result.metadata.dialect, Some(SlicerDialect::OrcaSlicer));
+        assert_eq!(result.metadata.confidence, Confidence::Low);
+    }
+
+    #[test]
+    fn given_no_signals_when_heuristic_then_unknown() {
+        let commands = vec![meta(1, 104, "S200")];
+        let result = detect_dialect(&commands, None);
+        assert_eq!(result.metadata.dialect, Some(SlicerDialect::Unknown));
+        assert_eq!(result.metadata.confidence, Confidence::None);
+    }
+
+    // ── dialect_override ─────────────────────────────────────────────────
+
+    #[test]
+    fn given_dialect_override_when_detected_then_uses_override() {
+        let commands = vec![comment(1, " generated by OrcaSlicer 2.1.0")];
+        let result = detect_dialect(&commands, Some(SlicerDialect::PrusaSlicer));
+        assert_eq!(result.metadata.dialect, Some(SlicerDialect::PrusaSlicer));
+        assert_eq!(result.metadata.confidence, Confidence::High);
+    }
+
+    #[test]
+    fn given_dialect_override_when_metadata_missing_then_no_w005() {
+        let commands = vec![comment(1, " just a comment")];
+        let result = detect_dialect(&commands, Some(SlicerDialect::OrcaSlicer));
+        let w005_count = result
+            .diagnostics
+            .iter()
+            .filter(|d| d.code == "W005")
+            .count();
+        assert_eq!(w005_count, 0);
+    }
+
+    // ── Metadata extraction: OrcaSlicer/PrusaSlicer footer ───────────────
+
+    #[test]
+    fn given_orca_footer_when_extracted_then_populates_all_fields() {
+        let mut commands = vec![comment(1, " generated by OrcaSlicer 2.1.0")];
+        // Pad to push footer into last 100
+        for i in 2..50 {
+            commands.push(meta(i, 1, "X10 Y10 E0.5"));
+        }
+        commands.push(comment(50, " nozzle_diameter = 0.4"));
+        commands.push(comment(51, " layer_height = 0.2"));
+        commands.push(comment(52, " filament_type = PLA"));
+        commands.push(comment(53, " first_layer_bed_temperature = 55"));
+        commands.push(comment(54, " nozzle_temperature = 210"));
+        commands.push(comment(
+            55,
+            " estimated printing time (normal mode) = 2h 26m 25s",
+        ));
+
+        let result = detect_dialect(&commands, None);
+        let m = &result.metadata;
+        assert_eq!(m.nozzle_diameter.as_deref(), Some("0.4"));
+        assert_eq!(m.layer_height.as_deref(), Some("0.2"));
+        assert_eq!(m.filament_type.as_deref(), Some("PLA"));
+        assert_eq!(m.bed_temperature.as_deref(), Some("55"));
+        assert_eq!(m.nozzle_temperature.as_deref(), Some("210"));
+        assert_eq!(m.estimated_print_time.as_deref(), Some("2h 26m 25s"));
+    }
+
+    #[test]
+    fn given_orca_footer_when_subkey_present_then_exact_match_only() {
+        // "nozzle_temperature_initial_layer" should NOT match "nozzle_temperature"
+        let mut commands = vec![comment(1, " generated by OrcaSlicer 2.0.0")];
+        commands.push(comment(2, " nozzle_temperature_initial_layer = 215"));
+        commands.push(comment(3, " nozzle_temperature = 210"));
+
+        let result = detect_dialect(&commands, None);
+        assert_eq!(result.metadata.nozzle_temperature.as_deref(), Some("210"));
+    }
+
+    // ── Metadata extraction: Cura header ─────────────────────────────────
+
+    #[test]
+    fn given_cura_header_when_extracted_then_populates_all_fields() {
+        let commands = vec![
+            comment(1, "FLAVOR:Marlin"),
+            comment(2, "Nozzle size: 0.4"),
+            comment(3, "Layer height: 0.2"),
+            comment(4, "PRINT.TIME:3600"),
+            comment(5, "Filament type: PLA"),
+            comment(6, "BUILD_PLATE.INITIAL_TEMPERATURE:60"),
+            comment(7, "EXTRUDER.INITIAL_TEMPERATURE:210"),
+        ];
+
+        let result = detect_dialect(&commands, None);
+        let m = &result.metadata;
+        assert_eq!(m.nozzle_diameter.as_deref(), Some("0.4"));
+        assert_eq!(m.layer_height.as_deref(), Some("0.2"));
+        assert_eq!(m.estimated_print_time.as_deref(), Some("3600"));
+        assert_eq!(m.filament_type.as_deref(), Some("PLA"));
+        assert_eq!(m.bed_temperature.as_deref(), Some("60"));
+        assert_eq!(m.nozzle_temperature.as_deref(), Some("210"));
+    }
+
+    // ── Diagnostics ──────────────────────────────────────────────────────
+
+    #[test]
+    fn given_detected_dialect_when_result_then_emits_i004() {
+        let commands = vec![comment(1, " generated by OrcaSlicer 2.0.0")];
+        let result = detect_dialect(&commands, None);
+        let i004 = result.diagnostics.iter().find(|d| d.code == "I004");
+        assert!(i004.is_some());
+        assert_eq!(i004.unwrap().severity, Severity::Info);
+        assert_eq!(i004.unwrap().line, 1);
+    }
+
+    #[test]
+    fn given_unknown_dialect_when_result_then_no_i004() {
+        let commands = vec![meta(1, 104, "S200")];
+        let result = detect_dialect(&commands, None);
+        let i004 = result.diagnostics.iter().find(|d| d.code == "I004");
+        assert!(i004.is_none());
+    }
+
+    #[test]
+    fn given_missing_metadata_when_detected_then_emits_w005() {
+        let commands = vec![comment(1, " generated by OrcaSlicer 2.0.0")];
+        let result = detect_dialect(&commands, None);
+        let w005s: Vec<_> = result
+            .diagnostics
+            .iter()
+            .filter(|d| d.code == "W005")
+            .collect();
+        // All 6 fields missing
+        assert_eq!(w005s.len(), 6);
+        assert!(w005s.iter().all(|d| d.severity == Severity::Warning));
+    }
+
+    #[test]
+    fn given_all_metadata_present_when_detected_then_no_w005() {
+        let mut commands = vec![comment(1, " generated by OrcaSlicer 2.0.0")];
+        commands.push(comment(2, " nozzle_diameter = 0.4"));
+        commands.push(comment(3, " layer_height = 0.2"));
+        commands.push(comment(4, " filament_type = PLA"));
+        commands.push(comment(5, " first_layer_bed_temperature = 55"));
+        commands.push(comment(6, " nozzle_temperature = 210"));
+        commands.push(comment(
+            7,
+            " estimated printing time (normal mode) = 2h 26m 25s",
+        ));
+
+        let result = detect_dialect(&commands, None);
+        let w005s: Vec<_> = result
+            .diagnostics
+            .iter()
+            .filter(|d| d.code == "W005")
+            .collect();
+        assert_eq!(w005s.len(), 0);
+    }
+
+    // ── Serialization ────────────────────────────────────────────────────
+
+    #[test]
+    fn given_confidence_when_serialized_then_json_string() {
+        let json = serde_json::to_string(&Confidence::High).unwrap();
+        assert_eq!(json, r#""High""#);
+    }
+
+    #[test]
+    fn given_slicer_dialect_when_serialized_then_json_string() {
+        let json = serde_json::to_string(&SlicerDialect::OrcaSlicer).unwrap();
+        assert_eq!(json, r#""OrcaSlicer""#);
+    }
+
+    #[test]
+    fn given_metadata_when_serialized_then_valid_json() {
+        let m = SlicerMetadata {
+            dialect: Some(SlicerDialect::Cura),
+            confidence: Confidence::High,
+            nozzle_diameter: Some("0.4".to_string()),
+            ..SlicerMetadata::default()
+        };
+        let json = serde_json::to_string(&m).unwrap();
+        assert!(json.contains("\"Cura\""));
+        assert!(json.contains("\"0.4\""));
+    }
+
+    // ── Edge cases ───────────────────────────────────────────────────────
+
+    #[test]
+    fn given_empty_commands_when_detected_then_unknown() {
+        let result = detect_dialect(&[], None);
+        assert_eq!(result.metadata.dialect, Some(SlicerDialect::Unknown));
+        assert_eq!(result.metadata.confidence, Confidence::None);
+    }
+
+    #[test]
+    fn given_signature_beyond_100_lines_when_detected_then_not_found_in_phase1() {
+        let mut commands: Vec<Spanned<GCodeCommand<'_>>> = Vec::new();
+        for i in 1..=100 {
+            commands.push(meta(i, 1, "X10 Y10"));
+        }
+        commands.push(comment(101, " generated by OrcaSlicer 2.0.0"));
+        let result = detect_dialect(&commands, None);
+        // Phase 1 won't find it; heuristics won't match either
+        assert_eq!(result.metadata.dialect, Some(SlicerDialect::Unknown));
+    }
+}

--- a/src/dialect.rs
+++ b/src/dialect.rs
@@ -95,6 +95,32 @@ pub struct SlicerMetadata {
     pub estimated_time_seconds: Option<f64>,
 }
 
+impl SlicerMetadata {
+    /// Collect names of expected metadata fields that are missing.
+    #[must_use]
+    pub fn missing_fields(&self, expected: &[&'static str]) -> Vec<&'static str> {
+        let mut missing = Vec::new();
+        for &field in expected {
+            let present = match field {
+                "nozzle_diameter_mm" => self.nozzle_diameter_mm.is_some(),
+                "layer_height_mm" => self.layer_height_mm.is_some(),
+                "filament_type" => self.filament_type.is_some(),
+                "first_layer_bed_temperature" | "bed_temperature" => self.bed_temperature.is_some(),
+                "hotend_temperature" => self.hotend_temperature.is_some(),
+                "estimated_time_seconds" | "print_time" => self.estimated_time_seconds.is_some(),
+                _ => {
+                    debug_assert!(false, "unhandled expected field: {field}");
+                    true
+                }
+            };
+            if !present {
+                missing.push(field);
+            }
+        }
+        missing
+    }
+}
+
 impl Default for SlicerMetadata {
     fn default() -> Self {
         Self {
@@ -159,7 +185,9 @@ pub fn detect_dialect(
                     phase1_line = cmd.line;
                     metadata.slicer_version = extract_version_after(text, "PrusaSlicer");
                     break;
-                } else if lower.contains("flavor:") || lower.contains("generated with cura") {
+                } else if lower.trim().starts_with("flavor:")
+                    || lower.contains("generated with cura")
+                {
                     phase1_dialect = Some(SlicerDialect::Cura);
                     phase1_line = cmd.line;
                     if lower.contains("generated with cura") {
@@ -184,7 +212,7 @@ pub fn detect_dialect(
     metadata.confidence = confidence;
 
     // Extract metadata based on dialect
-    extract_metadata(commands, dialect, &mut metadata);
+    extract_metadata(commands, dialect, &mut metadata, &mut diagnostics);
 
     // Emit I004 diagnostic
     let detection_line = if dialect_override.is_some() {
@@ -207,7 +235,7 @@ pub fn detect_dialect(
     // W005: expected metadata missing (suppressed when dialect_override is Some)
     if dialect_override.is_none() && dialect != SlicerDialect::Unknown {
         let expected = dialect.expected_fields();
-        let missing = collect_missing_fields(&metadata, expected);
+        let missing = metadata.missing_fields(expected);
         for field in missing {
             diagnostics.push(Diagnostic {
                 severity: Severity::Warning,
@@ -293,6 +321,7 @@ fn extract_metadata(
     commands: &[Spanned<GCodeCommand<'_>>],
     dialect: SlicerDialect,
     metadata: &mut SlicerMetadata,
+    diagnostics: &mut Vec<Diagnostic>,
 ) {
     match dialect {
         SlicerDialect::OrcaSlicer | SlicerDialect::PrusaSlicer => {
@@ -311,7 +340,7 @@ fn extract_metadata(
             };
             for cmd in &commands[config_start..] {
                 if let GCodeCommand::Comment { text } = &cmd.inner {
-                    extract_orca_prusa_field(text, metadata);
+                    extract_orca_prusa_field(text, metadata, diagnostics);
                 }
             }
         }
@@ -320,7 +349,7 @@ fn extract_metadata(
             let limit = commands.len().min(100);
             for cmd in &commands[..limit] {
                 if let GCodeCommand::Comment { text } = &cmd.inner {
-                    extract_cura_field(text, metadata);
+                    extract_cura_field(text, metadata, diagnostics);
                 }
             }
         }
@@ -332,7 +361,11 @@ fn extract_metadata(
 ///
 /// Expected format: ` key = value` (with leading space after semicolon stripped
 /// by the parser). Uses exact key matching to avoid sub-key collisions.
-fn extract_orca_prusa_field(text: &str, metadata: &mut SlicerMetadata) {
+fn extract_orca_prusa_field(
+    text: &str,
+    metadata: &mut SlicerMetadata,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
     let trimmed = text.trim();
 
     // Split on first '=' only
@@ -341,21 +374,59 @@ fn extract_orca_prusa_field(text: &str, metadata: &mut SlicerMetadata) {
         let value = value.trim();
 
         match key {
-            "nozzle_diameter" => {
-                metadata.nozzle_diameter_mm = value.parse::<f64>().ok();
-            }
-            "layer_height" => {
-                metadata.layer_height_mm = value.parse::<f64>().ok();
-            }
+            "nozzle_diameter" => match value.parse::<f64>() {
+                Ok(v) if v.is_finite() => metadata.nozzle_diameter_mm = Some(v),
+                _ => {
+                    diagnostics.push(Diagnostic {
+                        severity: Severity::Warning,
+                        line: 0,
+                        code: "W007",
+                        message: format!(
+                            "nozzle_diameter present but value unparseable: \"{value}\""
+                        ),
+                    });
+                }
+            },
+            "layer_height" => match value.parse::<f64>() {
+                Ok(v) if v.is_finite() => metadata.layer_height_mm = Some(v),
+                _ => {
+                    diagnostics.push(Diagnostic {
+                        severity: Severity::Warning,
+                        line: 0,
+                        code: "W007",
+                        message: format!("layer_height present but value unparseable: \"{value}\""),
+                    });
+                }
+            },
             "filament_type" => {
                 metadata.filament_type = Some(value.to_string());
             }
-            "first_layer_bed_temperature" => {
-                metadata.bed_temperature = value.parse::<f64>().ok();
-            }
-            "nozzle_temperature" => {
-                metadata.hotend_temperature = value.parse::<f64>().ok();
-            }
+            "first_layer_bed_temperature" => match value.parse::<f64>() {
+                Ok(v) if v.is_finite() => metadata.bed_temperature = Some(v),
+                _ => {
+                    diagnostics.push(Diagnostic {
+                        severity: Severity::Warning,
+                        line: 0,
+                        code: "W007",
+                        message: format!(
+                            "first_layer_bed_temperature present but value unparseable: \"{value}\""
+                        ),
+                    });
+                }
+            },
+            "nozzle_temperature" => match value.parse::<f64>() {
+                Ok(v) if v.is_finite() => metadata.hotend_temperature = Some(v),
+                _ => {
+                    diagnostics.push(Diagnostic {
+                        severity: Severity::Warning,
+                        line: 0,
+                        code: "W007",
+                        message: format!(
+                            "nozzle_temperature present but value unparseable: \"{value}\""
+                        ),
+                    });
+                }
+            },
             _ => {}
         }
     }
@@ -378,21 +449,84 @@ fn extract_orca_prusa_field(text: &str, metadata: &mut SlicerMetadata) {
 /// - `Filament type: PLA`
 /// - `BUILD_PLATE.INITIAL_TEMPERATURE:60`
 /// - `EXTRUDER.INITIAL_TEMPERATURE:210`
-fn extract_cura_field(text: &str, metadata: &mut SlicerMetadata) {
+fn extract_cura_field(
+    text: &str,
+    metadata: &mut SlicerMetadata,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
     let trimmed = text.trim();
 
     if let Some(val) = trimmed.strip_prefix("Nozzle size:") {
-        metadata.nozzle_diameter_mm = val.trim().parse::<f64>().ok();
+        let val = val.trim();
+        match val.parse::<f64>() {
+            Ok(v) if v.is_finite() => metadata.nozzle_diameter_mm = Some(v),
+            _ => {
+                diagnostics.push(Diagnostic {
+                    severity: Severity::Warning,
+                    line: 0,
+                    code: "W007",
+                    message: format!("Nozzle size present but value unparseable: \"{val}\""),
+                });
+            }
+        }
     } else if let Some(val) = trimmed.strip_prefix("Layer height:") {
-        metadata.layer_height_mm = val.trim().parse::<f64>().ok();
+        let val = val.trim();
+        match val.parse::<f64>() {
+            Ok(v) if v.is_finite() => metadata.layer_height_mm = Some(v),
+            _ => {
+                diagnostics.push(Diagnostic {
+                    severity: Severity::Warning,
+                    line: 0,
+                    code: "W007",
+                    message: format!("Layer height present but value unparseable: \"{val}\""),
+                });
+            }
+        }
     } else if let Some(val) = trimmed.strip_prefix("PRINT.TIME:") {
-        metadata.estimated_time_seconds = val.trim().parse::<f64>().ok();
+        let val = val.trim();
+        match val.parse::<f64>() {
+            Ok(v) if v.is_finite() => metadata.estimated_time_seconds = Some(v),
+            _ => {
+                diagnostics.push(Diagnostic {
+                    severity: Severity::Warning,
+                    line: 0,
+                    code: "W007",
+                    message: format!("PRINT.TIME present but value unparseable: \"{val}\""),
+                });
+            }
+        }
     } else if let Some(val) = trimmed.strip_prefix("Filament type:") {
         metadata.filament_type = Some(val.trim().to_string());
     } else if let Some(val) = trimmed.strip_prefix("BUILD_PLATE.INITIAL_TEMPERATURE:") {
-        metadata.bed_temperature = val.trim().parse::<f64>().ok();
+        let val = val.trim();
+        match val.parse::<f64>() {
+            Ok(v) if v.is_finite() => metadata.bed_temperature = Some(v),
+            _ => {
+                diagnostics.push(Diagnostic {
+                    severity: Severity::Warning,
+                    line: 0,
+                    code: "W007",
+                    message: format!(
+                        "BUILD_PLATE.INITIAL_TEMPERATURE present but value unparseable: \"{val}\""
+                    ),
+                });
+            }
+        }
     } else if let Some(val) = trimmed.strip_prefix("EXTRUDER.INITIAL_TEMPERATURE:") {
-        metadata.hotend_temperature = val.trim().parse::<f64>().ok();
+        let val = val.trim();
+        match val.parse::<f64>() {
+            Ok(v) if v.is_finite() => metadata.hotend_temperature = Some(v),
+            _ => {
+                diagnostics.push(Diagnostic {
+                    severity: Severity::Warning,
+                    line: 0,
+                    code: "W007",
+                    message: format!(
+                        "EXTRUDER.INITIAL_TEMPERATURE present but value unparseable: \"{val}\""
+                    ),
+                });
+            }
+        }
     }
 }
 
@@ -414,6 +548,12 @@ fn parse_time_estimate(text: &str) -> Option<f64> {
             current_num.clear();
         }
     }
+    // Treat trailing digits without a suffix as raw seconds.
+    if !current_num.is_empty() {
+        if let Ok(n) = current_num.parse::<f64>() {
+            total += n;
+        }
+    }
     if total > 0.0 {
         Some(total)
     } else {
@@ -421,9 +561,11 @@ fn parse_time_estimate(text: &str) -> Option<f64> {
     }
 }
 
-/// Extract a version number that follows a keyword in a comment.
+/// Extract a version number that follows a keyword in a comment (case-insensitive).
 fn extract_version_after(text: &str, keyword: &str) -> Option<String> {
-    let idx = text.find(keyword)?;
+    let lower = text.to_lowercase();
+    let kw_lower = keyword.to_lowercase();
+    let idx = lower.find(&kw_lower)?;
     let after = &text[idx + keyword.len()..];
     let trimmed = after.trim();
     // Take the first whitespace-delimited token as the version
@@ -433,29 +575,6 @@ fn extract_version_after(text: &str, keyword: &str) -> Option<String> {
     } else {
         Some(version.to_string())
     }
-}
-
-/// Collect names of expected metadata fields that are missing.
-fn collect_missing_fields(
-    metadata: &SlicerMetadata,
-    expected: &[&'static str],
-) -> Vec<&'static str> {
-    let mut missing = Vec::new();
-    for &field in expected {
-        let present = match field {
-            "nozzle_diameter_mm" => metadata.nozzle_diameter_mm.is_some(),
-            "layer_height_mm" => metadata.layer_height_mm.is_some(),
-            "filament_type" => metadata.filament_type.is_some(),
-            "first_layer_bed_temperature" | "bed_temperature" => metadata.bed_temperature.is_some(),
-            "hotend_temperature" => metadata.hotend_temperature.is_some(),
-            "estimated_time_seconds" | "print_time" => metadata.estimated_time_seconds.is_some(),
-            _ => true,
-        };
-        if !present {
-            missing.push(field);
-        }
-    }
-    missing
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -572,6 +691,7 @@ mod tests {
         let result = detect_dialect(&commands, None);
         assert_eq!(result.metadata.dialect, SlicerDialect::OrcaSlicer);
         assert_eq!(result.metadata.confidence, Confidence::High);
+        assert_eq!(result.metadata.slicer_version.as_deref(), Some("2.0.0"));
     }
 
     // ── Phase 2: heuristic detection ─────────────────────────────────────
@@ -803,6 +923,95 @@ mod tests {
         commands.push(comment(101, " generated by OrcaSlicer 2.0.0"));
         let result = detect_dialect(&commands, None);
         // Phase 1 won't find it; heuristics won't match either
+        assert_eq!(result.metadata.dialect, SlicerDialect::Unknown);
+    }
+
+    // ── parse_time_estimate ─────────────────────────────────────────────
+
+    #[test]
+    fn given_hms_string_when_parsed_then_returns_total_seconds() {
+        assert_eq!(parse_time_estimate("2h 26m 25s"), Some(8785.0));
+    }
+
+    #[test]
+    fn given_minutes_seconds_when_parsed_then_returns_total_seconds() {
+        assert_eq!(parse_time_estimate("45m 10s"), Some(2710.0));
+    }
+
+    #[test]
+    fn given_seconds_only_when_parsed_then_returns_seconds() {
+        assert_eq!(parse_time_estimate("30s"), Some(30.0));
+    }
+
+    #[test]
+    fn given_raw_seconds_when_parsed_then_treats_as_seconds() {
+        assert_eq!(parse_time_estimate("3600"), Some(3600.0));
+    }
+
+    #[test]
+    fn given_trailing_digits_when_parsed_then_treats_as_seconds() {
+        assert_eq!(parse_time_estimate("2h 26m 25"), Some(8785.0));
+    }
+
+    #[test]
+    fn given_empty_string_when_parsed_then_returns_none() {
+        assert_eq!(parse_time_estimate(""), None);
+    }
+
+    #[test]
+    fn given_no_digits_when_parsed_then_returns_none() {
+        assert_eq!(parse_time_estimate("no time"), None);
+    }
+
+    // ── W007 diagnostics ────────────────────────────────────────────────
+
+    #[test]
+    fn given_unparseable_nozzle_diameter_when_extracted_then_emits_w007() {
+        let mut commands = vec![comment(1, " generated by OrcaSlicer 2.0.0")];
+        commands.push(comment(2, " nozzle_diameter = abc"));
+        let result = detect_dialect(&commands, None);
+        let w007s: Vec<_> = result
+            .diagnostics
+            .iter()
+            .filter(|d| d.code == "W007")
+            .collect();
+        assert_eq!(w007s.len(), 1);
+        assert!(w007s[0].message.contains("nozzle_diameter"));
+        assert!(w007s[0].message.contains("abc"));
+    }
+
+    #[test]
+    fn given_nan_value_when_extracted_then_emits_w007() {
+        let mut commands = vec![comment(1, " generated by OrcaSlicer 2.0.0")];
+        commands.push(comment(2, " nozzle_diameter = NaN"));
+        let result = detect_dialect(&commands, None);
+        let w007s: Vec<_> = result
+            .diagnostics
+            .iter()
+            .filter(|d| d.code == "W007")
+            .collect();
+        assert_eq!(w007s.len(), 1);
+    }
+
+    #[test]
+    fn given_infinity_value_when_extracted_then_emits_w007() {
+        let mut commands = vec![comment(1, " generated by OrcaSlicer 2.0.0")];
+        commands.push(comment(2, " layer_height = inf"));
+        let result = detect_dialect(&commands, None);
+        let w007s: Vec<_> = result
+            .diagnostics
+            .iter()
+            .filter(|d| d.code == "W007")
+            .collect();
+        assert_eq!(w007s.len(), 1);
+    }
+
+    // ── FLAVOR false positive ───────────────────────────────────────────
+
+    #[test]
+    fn given_flavor_in_middle_of_comment_when_detected_then_no_cura_match() {
+        let commands = vec![comment(1, " some text with flavor: something in it")];
+        let result = detect_dialect(&commands, None);
         assert_eq!(result.metadata.dialect, SlicerDialect::Unknown);
     }
 }

--- a/src/dialect.rs
+++ b/src/dialect.rs
@@ -48,19 +48,19 @@ impl SlicerDialect {
     pub fn expected_fields(self) -> &'static [&'static str] {
         match self {
             Self::OrcaSlicer | Self::PrusaSlicer => &[
-                "nozzle_diameter",
-                "layer_height",
+                "nozzle_diameter_mm",
+                "layer_height_mm",
                 "filament_type",
                 "first_layer_bed_temperature",
-                "nozzle_temperature",
-                "estimated_printing_time",
+                "hotend_temperature",
+                "estimated_time_seconds",
             ],
             Self::Cura => &[
-                "nozzle_diameter",
-                "layer_height",
+                "nozzle_diameter_mm",
+                "layer_height_mm",
                 "filament_type",
                 "bed_temperature",
-                "nozzle_temperature",
+                "hotend_temperature",
                 "print_time",
             ],
             Self::Unknown => &[],
@@ -73,26 +73,42 @@ impl SlicerDialect {
 // ──────────────────────────────────────────────────────────────────────────────
 
 /// Extracted slicer metadata from G-Code comments.
-#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct SlicerMetadata {
     /// Detected slicer dialect.
-    pub dialect: Option<SlicerDialect>,
+    pub dialect: SlicerDialect,
     /// Detection confidence level.
     pub confidence: Confidence,
     /// Slicer version string, if found.
     pub slicer_version: Option<String>,
-    /// Nozzle diameter in mm (as string, e.g. `"0.4"`).
-    pub nozzle_diameter: Option<String>,
-    /// Layer height in mm (as string, e.g. `"0.2"`).
-    pub layer_height: Option<String>,
+    /// Nozzle diameter in mm.
+    pub nozzle_diameter_mm: Option<f64>,
+    /// Layer height in mm.
+    pub layer_height_mm: Option<f64>,
     /// Filament type (e.g. `"PLA"`, `"PETG"`).
     pub filament_type: Option<String>,
-    /// Bed temperature for the first layer (as string, e.g. `"55"`).
-    pub bed_temperature: Option<String>,
-    /// Nozzle / hotend temperature (as string, e.g. `"210"`).
-    pub nozzle_temperature: Option<String>,
-    /// Estimated print time (raw string from slicer).
-    pub estimated_print_time: Option<String>,
+    /// Bed temperature for the first layer in degrees Celsius.
+    pub bed_temperature: Option<f64>,
+    /// Hotend temperature in degrees Celsius.
+    pub hotend_temperature: Option<f64>,
+    /// Estimated print time in seconds.
+    pub estimated_time_seconds: Option<f64>,
+}
+
+impl Default for SlicerMetadata {
+    fn default() -> Self {
+        Self {
+            dialect: SlicerDialect::Unknown,
+            confidence: Confidence::default(),
+            slicer_version: None,
+            nozzle_diameter_mm: None,
+            layer_height_mm: None,
+            filament_type: None,
+            bed_temperature: None,
+            hotend_temperature: None,
+            estimated_time_seconds: None,
+        }
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -164,7 +180,7 @@ pub fn detect_dialect(
         heuristic_detection(commands)
     };
 
-    metadata.dialect = Some(dialect);
+    metadata.dialect = dialect;
     metadata.confidence = confidence;
 
     // Extract metadata based on dialect
@@ -280,9 +296,20 @@ fn extract_metadata(
 ) {
     match dialect {
         SlicerDialect::OrcaSlicer | SlicerDialect::PrusaSlicer => {
-            // Footer: last 100 lines
-            let start = commands.len().saturating_sub(100);
-            for cmd in &commands[start..] {
+            // Find CONFIG_BLOCK_START marker scanning backwards; start a
+            // few lines earlier to catch metadata just before the block
+            // (e.g. `estimated printing time` which precedes CONFIG_BLOCK).
+            // Fall back to last 1000 commands for files without the marker.
+            let config_start = match commands.iter().rposition(|c| {
+                matches!(
+                    &c.inner,
+                    GCodeCommand::Comment { text } if text.contains("CONFIG_BLOCK_START")
+                )
+            }) {
+                Some(i) => i.saturating_sub(10),
+                None => commands.len().saturating_sub(1000),
+            };
+            for cmd in &commands[config_start..] {
                 if let GCodeCommand::Comment { text } = &cmd.inner {
                     extract_orca_prusa_field(text, metadata);
                 }
@@ -315,19 +342,19 @@ fn extract_orca_prusa_field(text: &str, metadata: &mut SlicerMetadata) {
 
         match key {
             "nozzle_diameter" => {
-                metadata.nozzle_diameter = Some(value.to_string());
+                metadata.nozzle_diameter_mm = value.parse::<f64>().ok();
             }
             "layer_height" => {
-                metadata.layer_height = Some(value.to_string());
+                metadata.layer_height_mm = value.parse::<f64>().ok();
             }
             "filament_type" => {
                 metadata.filament_type = Some(value.to_string());
             }
             "first_layer_bed_temperature" => {
-                metadata.bed_temperature = Some(value.to_string());
+                metadata.bed_temperature = value.parse::<f64>().ok();
             }
             "nozzle_temperature" => {
-                metadata.nozzle_temperature = Some(value.to_string());
+                metadata.hotend_temperature = value.parse::<f64>().ok();
             }
             _ => {}
         }
@@ -337,7 +364,7 @@ fn extract_orca_prusa_field(text: &str, metadata: &mut SlicerMetadata) {
     // "; estimated printing time (normal mode) = 2h 26m 25s"
     if trimmed.starts_with("estimated printing time") {
         if let Some((_, value)) = trimmed.split_once('=') {
-            metadata.estimated_print_time = Some(value.trim().to_string());
+            metadata.estimated_time_seconds = parse_time_estimate(value.trim());
         }
     }
 }
@@ -355,17 +382,42 @@ fn extract_cura_field(text: &str, metadata: &mut SlicerMetadata) {
     let trimmed = text.trim();
 
     if let Some(val) = trimmed.strip_prefix("Nozzle size:") {
-        metadata.nozzle_diameter = Some(val.trim().to_string());
+        metadata.nozzle_diameter_mm = val.trim().parse::<f64>().ok();
     } else if let Some(val) = trimmed.strip_prefix("Layer height:") {
-        metadata.layer_height = Some(val.trim().to_string());
+        metadata.layer_height_mm = val.trim().parse::<f64>().ok();
     } else if let Some(val) = trimmed.strip_prefix("PRINT.TIME:") {
-        metadata.estimated_print_time = Some(val.trim().to_string());
+        metadata.estimated_time_seconds = val.trim().parse::<f64>().ok();
     } else if let Some(val) = trimmed.strip_prefix("Filament type:") {
         metadata.filament_type = Some(val.trim().to_string());
     } else if let Some(val) = trimmed.strip_prefix("BUILD_PLATE.INITIAL_TEMPERATURE:") {
-        metadata.bed_temperature = Some(val.trim().to_string());
+        metadata.bed_temperature = val.trim().parse::<f64>().ok();
     } else if let Some(val) = trimmed.strip_prefix("EXTRUDER.INITIAL_TEMPERATURE:") {
-        metadata.nozzle_temperature = Some(val.trim().to_string());
+        metadata.hotend_temperature = val.trim().parse::<f64>().ok();
+    }
+}
+
+/// Parse a time estimate string like "2h 26m 25s" into total seconds.
+fn parse_time_estimate(text: &str) -> Option<f64> {
+    let mut total = 0.0_f64;
+    let mut current_num = String::new();
+    for c in text.chars() {
+        if c.is_ascii_digit() {
+            current_num.push(c);
+        } else if !current_num.is_empty() {
+            let n: f64 = current_num.parse().ok()?;
+            match c {
+                'h' => total += n * 3600.0,
+                'm' => total += n * 60.0,
+                's' => total += n,
+                _ => {}
+            }
+            current_num.clear();
+        }
+    }
+    if total > 0.0 {
+        Some(total)
+    } else {
+        None
     }
 }
 
@@ -391,12 +443,12 @@ fn collect_missing_fields(
     let mut missing = Vec::new();
     for &field in expected {
         let present = match field {
-            "nozzle_diameter" => metadata.nozzle_diameter.is_some(),
-            "layer_height" => metadata.layer_height.is_some(),
+            "nozzle_diameter_mm" => metadata.nozzle_diameter_mm.is_some(),
+            "layer_height_mm" => metadata.layer_height_mm.is_some(),
             "filament_type" => metadata.filament_type.is_some(),
             "first_layer_bed_temperature" | "bed_temperature" => metadata.bed_temperature.is_some(),
-            "nozzle_temperature" => metadata.nozzle_temperature.is_some(),
-            "estimated_printing_time" | "print_time" => metadata.estimated_print_time.is_some(),
+            "hotend_temperature" => metadata.hotend_temperature.is_some(),
+            "estimated_time_seconds" | "print_time" => metadata.estimated_time_seconds.is_some(),
             _ => true,
         };
         if !present {
@@ -453,8 +505,8 @@ mod tests {
     fn given_orcaslicer_when_expected_fields_then_returns_six_fields() {
         let fields = SlicerDialect::OrcaSlicer.expected_fields();
         assert_eq!(fields.len(), 6);
-        assert!(fields.contains(&"nozzle_diameter"));
-        assert!(fields.contains(&"estimated_printing_time"));
+        assert!(fields.contains(&"nozzle_diameter_mm"));
+        assert!(fields.contains(&"estimated_time_seconds"));
     }
 
     #[test]
@@ -478,7 +530,7 @@ mod tests {
             comment(2, " some other comment"),
         ];
         let result = detect_dialect(&commands, None);
-        assert_eq!(result.metadata.dialect, Some(SlicerDialect::OrcaSlicer));
+        assert_eq!(result.metadata.dialect, SlicerDialect::OrcaSlicer);
         assert_eq!(result.metadata.confidence, Confidence::High);
         assert_eq!(result.metadata.slicer_version.as_deref(), Some("2.1.0"));
     }
@@ -490,7 +542,7 @@ mod tests {
             " generated by PrusaSlicer 2.7.1+linux on 2024-03-01",
         )];
         let result = detect_dialect(&commands, None);
-        assert_eq!(result.metadata.dialect, Some(SlicerDialect::PrusaSlicer));
+        assert_eq!(result.metadata.dialect, SlicerDialect::PrusaSlicer);
         assert_eq!(result.metadata.confidence, Confidence::High);
         assert_eq!(
             result.metadata.slicer_version.as_deref(),
@@ -502,7 +554,7 @@ mod tests {
     fn given_cura_flavor_comment_when_detected_then_high_confidence() {
         let commands = vec![comment(1, "FLAVOR:Marlin")];
         let result = detect_dialect(&commands, None);
-        assert_eq!(result.metadata.dialect, Some(SlicerDialect::Cura));
+        assert_eq!(result.metadata.dialect, SlicerDialect::Cura);
         assert_eq!(result.metadata.confidence, Confidence::High);
     }
 
@@ -510,7 +562,7 @@ mod tests {
     fn given_cura_generated_with_comment_when_detected_then_extracts_version() {
         let commands = vec![comment(1, " Generated with Cura_SteamEngine 5.6.0")];
         let result = detect_dialect(&commands, None);
-        assert_eq!(result.metadata.dialect, Some(SlicerDialect::Cura));
+        assert_eq!(result.metadata.dialect, SlicerDialect::Cura);
         assert_eq!(result.metadata.slicer_version.as_deref(), Some("5.6.0"));
     }
 
@@ -518,7 +570,7 @@ mod tests {
     fn given_case_insensitive_header_when_detected_then_matches() {
         let commands = vec![comment(1, " GENERATED BY ORCASLICER 2.0.0")];
         let result = detect_dialect(&commands, None);
-        assert_eq!(result.metadata.dialect, Some(SlicerDialect::OrcaSlicer));
+        assert_eq!(result.metadata.dialect, SlicerDialect::OrcaSlicer);
         assert_eq!(result.metadata.confidence, Confidence::High);
     }
 
@@ -528,7 +580,7 @@ mod tests {
     fn given_m73_with_p_and_r_when_heuristic_then_orca_signal() {
         let commands = vec![meta(1, 73, "P50 R30"), meta(2, 73, "P75 R15")];
         let result = detect_dialect(&commands, None);
-        assert_eq!(result.metadata.dialect, Some(SlicerDialect::OrcaSlicer));
+        assert_eq!(result.metadata.dialect, SlicerDialect::OrcaSlicer);
         assert_eq!(result.metadata.confidence, Confidence::Medium);
     }
 
@@ -536,7 +588,7 @@ mod tests {
     fn given_m73_with_p_only_when_heuristic_then_cura_signal() {
         let commands = vec![meta(1, 73, "P50"), meta(2, 73, "P75")];
         let result = detect_dialect(&commands, None);
-        assert_eq!(result.metadata.dialect, Some(SlicerDialect::Cura));
+        assert_eq!(result.metadata.dialect, SlicerDialect::Cura);
         assert_eq!(result.metadata.confidence, Confidence::Medium);
     }
 
@@ -544,7 +596,7 @@ mod tests {
     fn given_m900_when_heuristic_then_prusaslicer_signal() {
         let commands = vec![meta(1, 900, "K0.04"), comment(2, "TYPE:External perimeter")];
         let result = detect_dialect(&commands, None);
-        assert_eq!(result.metadata.dialect, Some(SlicerDialect::PrusaSlicer));
+        assert_eq!(result.metadata.dialect, SlicerDialect::PrusaSlicer);
         assert_eq!(result.metadata.confidence, Confidence::Medium);
     }
 
@@ -552,7 +604,7 @@ mod tests {
     fn given_single_type_comment_when_heuristic_then_low_confidence() {
         let commands = vec![comment(1, "TYPE:Infill")];
         let result = detect_dialect(&commands, None);
-        assert_eq!(result.metadata.dialect, Some(SlicerDialect::OrcaSlicer));
+        assert_eq!(result.metadata.dialect, SlicerDialect::OrcaSlicer);
         assert_eq!(result.metadata.confidence, Confidence::Low);
     }
 
@@ -560,7 +612,7 @@ mod tests {
     fn given_no_signals_when_heuristic_then_unknown() {
         let commands = vec![meta(1, 104, "S200")];
         let result = detect_dialect(&commands, None);
-        assert_eq!(result.metadata.dialect, Some(SlicerDialect::Unknown));
+        assert_eq!(result.metadata.dialect, SlicerDialect::Unknown);
         assert_eq!(result.metadata.confidence, Confidence::None);
     }
 
@@ -570,7 +622,7 @@ mod tests {
     fn given_dialect_override_when_detected_then_uses_override() {
         let commands = vec![comment(1, " generated by OrcaSlicer 2.1.0")];
         let result = detect_dialect(&commands, Some(SlicerDialect::PrusaSlicer));
-        assert_eq!(result.metadata.dialect, Some(SlicerDialect::PrusaSlicer));
+        assert_eq!(result.metadata.dialect, SlicerDialect::PrusaSlicer);
         assert_eq!(result.metadata.confidence, Confidence::High);
     }
 
@@ -607,12 +659,12 @@ mod tests {
 
         let result = detect_dialect(&commands, None);
         let m = &result.metadata;
-        assert_eq!(m.nozzle_diameter.as_deref(), Some("0.4"));
-        assert_eq!(m.layer_height.as_deref(), Some("0.2"));
+        assert_eq!(m.nozzle_diameter_mm, Some(0.4));
+        assert_eq!(m.layer_height_mm, Some(0.2));
         assert_eq!(m.filament_type.as_deref(), Some("PLA"));
-        assert_eq!(m.bed_temperature.as_deref(), Some("55"));
-        assert_eq!(m.nozzle_temperature.as_deref(), Some("210"));
-        assert_eq!(m.estimated_print_time.as_deref(), Some("2h 26m 25s"));
+        assert_eq!(m.bed_temperature, Some(55.0));
+        assert_eq!(m.hotend_temperature, Some(210.0));
+        assert_eq!(m.estimated_time_seconds, Some(8785.0));
     }
 
     #[test]
@@ -623,7 +675,7 @@ mod tests {
         commands.push(comment(3, " nozzle_temperature = 210"));
 
         let result = detect_dialect(&commands, None);
-        assert_eq!(result.metadata.nozzle_temperature.as_deref(), Some("210"));
+        assert_eq!(result.metadata.hotend_temperature, Some(210.0));
     }
 
     // ── Metadata extraction: Cura header ─────────────────────────────────
@@ -642,12 +694,12 @@ mod tests {
 
         let result = detect_dialect(&commands, None);
         let m = &result.metadata;
-        assert_eq!(m.nozzle_diameter.as_deref(), Some("0.4"));
-        assert_eq!(m.layer_height.as_deref(), Some("0.2"));
-        assert_eq!(m.estimated_print_time.as_deref(), Some("3600"));
+        assert_eq!(m.nozzle_diameter_mm, Some(0.4));
+        assert_eq!(m.layer_height_mm, Some(0.2));
+        assert_eq!(m.estimated_time_seconds, Some(3600.0));
         assert_eq!(m.filament_type.as_deref(), Some("PLA"));
-        assert_eq!(m.bed_temperature.as_deref(), Some("60"));
-        assert_eq!(m.nozzle_temperature.as_deref(), Some("210"));
+        assert_eq!(m.bed_temperature, Some(60.0));
+        assert_eq!(m.hotend_temperature, Some(210.0));
     }
 
     // ── Diagnostics ──────────────────────────────────────────────────────
@@ -723,14 +775,14 @@ mod tests {
     #[test]
     fn given_metadata_when_serialized_then_valid_json() {
         let m = SlicerMetadata {
-            dialect: Some(SlicerDialect::Cura),
+            dialect: SlicerDialect::Cura,
             confidence: Confidence::High,
-            nozzle_diameter: Some("0.4".to_string()),
+            nozzle_diameter_mm: Some(0.4),
             ..SlicerMetadata::default()
         };
         let json = serde_json::to_string(&m).unwrap();
         assert!(json.contains("\"Cura\""));
-        assert!(json.contains("\"0.4\""));
+        assert!(json.contains("0.4"));
     }
 
     // ── Edge cases ───────────────────────────────────────────────────────
@@ -738,7 +790,7 @@ mod tests {
     #[test]
     fn given_empty_commands_when_detected_then_unknown() {
         let result = detect_dialect(&[], None);
-        assert_eq!(result.metadata.dialect, Some(SlicerDialect::Unknown));
+        assert_eq!(result.metadata.dialect, SlicerDialect::Unknown);
         assert_eq!(result.metadata.confidence, Confidence::None);
     }
 
@@ -751,6 +803,6 @@ mod tests {
         commands.push(comment(101, " generated by OrcaSlicer 2.0.0"));
         let result = detect_dialect(&commands, None);
         // Phase 1 won't find it; heuristics won't match either
-        assert_eq!(result.metadata.dialect, Some(SlicerDialect::Unknown));
+        assert_eq!(result.metadata.dialect, SlicerDialect::Unknown);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod analyzer;
 pub mod arc_fitter;
 pub mod cli;
 pub mod diagnostics;
+pub mod dialect;
 pub mod emitter;
 pub(crate) mod geometry;
 pub mod machine_profile;

--- a/src/main.rs
+++ b/src/main.rs
@@ -350,7 +350,7 @@ fn check_profile_conflicts(
     let slicer_nozzle = metadata.nozzle_diameter_mm;
 
     if let (Some(slicer_val), Some(profile_val)) = (slicer_nozzle, profile.nozzle_diameter_mm) {
-        if (slicer_val - profile_val).abs() > f64::EPSILON {
+        if (slicer_val - profile_val).abs() > 1e-4 {
             let line = find_metadata_line(commands, "nozzle_diameter");
             diagnostics.push(gcode_sentinel::diagnostics::Diagnostic {
                 severity: Severity::Warning,
@@ -370,12 +370,14 @@ fn find_metadata_line(
 ) -> u32 {
     for cmd in commands.iter().rev() {
         if let gcode_sentinel::models::GCodeCommand::Comment { text } = &cmd.inner {
-            if text.contains(key) {
-                return cmd.line;
+            if let Some((k, _)) = text.trim().split_once('=') {
+                if k.trim() == key {
+                    return cmd.line;
+                }
             }
         }
     }
-    1
+    0
 }
 
 fn write_output(

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,11 +12,13 @@ use gcode_sentinel::analyzer::analyze;
 use gcode_sentinel::arc_fitter::{fit_arcs, ArcFitConfig, DEFAULT_ARC_TOLERANCE_MM};
 use gcode_sentinel::cli::{Cli, ReportFormat};
 use gcode_sentinel::diagnostics::{AnalysisReport, OptimizationChange, Severity, ValidationDiff};
+use gcode_sentinel::dialect::detect_dialect;
 use gcode_sentinel::emitter::{emit, EmitConfig};
 use gcode_sentinel::machine_profile::{self, MachineProfile};
 use gcode_sentinel::optimizer::{optimize, OptConfig};
 use gcode_sentinel::parser::parse_all;
 
+#[allow(clippy::too_many_lines)]
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
@@ -33,6 +35,28 @@ fn main() -> Result<()> {
     let text = map_input(&cli)?;
     let commands = parse_all(&text).context("parse error in input file")?;
     info!(commands = commands.len(), "parse complete");
+
+    let dialect_override = cli
+        .dialect
+        .map(gcode_sentinel::cli::CliDialect::to_slicer_dialect);
+    let dialect_result = detect_dialect(&commands, dialect_override);
+    if dialect_result.metadata.dialect != gcode_sentinel::dialect::SlicerDialect::Unknown {
+        info!(
+            dialect = ?dialect_result.metadata.dialect,
+            confidence = ?dialect_result.metadata.confidence,
+            "slicer dialect detected"
+        );
+    }
+
+    let mut dialect_diagnostics = dialect_result.diagnostics;
+    if let Some(ref profile) = profile {
+        check_profile_conflicts(
+            &dialect_result.metadata,
+            profile,
+            &commands,
+            &mut dialect_diagnostics,
+        );
+    }
 
     let pre_analysis = analyze(commands.iter(), limits.as_ref());
     log_analysis(&pre_analysis.diagnostics);
@@ -99,8 +123,15 @@ fn main() -> Result<()> {
         );
     }
 
-    let mut report = build_report(post_analysis, all_changes, effective_dry_run);
+    let mut report = build_report(
+        post_analysis,
+        all_changes,
+        effective_dry_run,
+        Some(dialect_result.metadata),
+    );
 
+    // Add dialect detection diagnostics (I004, W005, W006).
+    report.diagnostics.extend(dialect_diagnostics);
     // Add arc fitting diagnostics (e.g. W004 firmware warning).
     report.diagnostics.extend(arc_result.diagnostics);
     // Add progress insertion diagnostics.
@@ -260,12 +291,14 @@ fn build_report(
     analysis: gcode_sentinel::analyzer::AnalysisResult,
     changes: Vec<OptimizationChange>,
     dry_run: bool,
+    slicer: Option<gcode_sentinel::dialect::SlicerMetadata>,
 ) -> AnalysisReport {
     AnalysisReport {
         diagnostics: analysis.diagnostics,
         stats: analysis.stats,
         changes,
         dry_run,
+        slicer,
     }
 }
 
@@ -306,6 +339,43 @@ fn write_report_file(cli: &Cli, report: &AnalysisReport) -> Result<()> {
     }
     info!(path = %path.display(), format = ?cli.report_format, "report file written");
     Ok(())
+}
+
+fn check_profile_conflicts(
+    metadata: &gcode_sentinel::dialect::SlicerMetadata,
+    profile: &MachineProfile,
+    commands: &[gcode_sentinel::models::Spanned<gcode_sentinel::models::GCodeCommand<'_>>],
+    diagnostics: &mut Vec<gcode_sentinel::diagnostics::Diagnostic>,
+) {
+    let slicer_nozzle = metadata.nozzle_diameter_mm;
+
+    if let (Some(slicer_val), Some(profile_val)) = (slicer_nozzle, profile.nozzle_diameter_mm) {
+        if (slicer_val - profile_val).abs() > f64::EPSILON {
+            let line = find_metadata_line(commands, "nozzle_diameter");
+            diagnostics.push(gcode_sentinel::diagnostics::Diagnostic {
+                severity: Severity::Warning,
+                line,
+                code: "W006",
+                message: format!(
+                    "slicer nozzle_diameter ({slicer_val}) differs from machine profile ({profile_val})"
+                ),
+            });
+        }
+    }
+}
+
+fn find_metadata_line(
+    commands: &[gcode_sentinel::models::Spanned<gcode_sentinel::models::GCodeCommand<'_>>],
+    key: &str,
+) -> u32 {
+    for cmd in commands.iter().rev() {
+        if let gcode_sentinel::models::GCodeCommand::Comment { text } = &cmd.inner {
+            if text.contains(key) {
+                return cmd.line;
+            }
+        }
+    }
+    1
 }
 
 fn write_output(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -699,6 +699,17 @@ fn arc_fit_preserves_extrusion_on_existing_fixtures() {
     }
 }
 
+// ── CLI parsing ─────────────────────────────────────────────────────────────
+
+#[test]
+fn cli_dialect_flag_parsed() {
+    use clap::Parser;
+    use gcode_sentinel::cli::Cli;
+    let cli =
+        Cli::try_parse_from(["gcode-sentinel", "input.gcode", "--dialect", "orca-slicer"]).unwrap();
+    assert!(cli.dialect.is_some());
+}
+
 // ── Dialect detection ───────────────────────────────────────────────────────
 
 #[test]
@@ -745,4 +756,46 @@ fn detect_dialect_rose_is_orcaslicer() {
         result.metadata.confidence,
         gcode_sentinel::dialect::Confidence::High
     );
+}
+
+#[test]
+fn detect_dialect_override_suppresses_w005() {
+    let text = fs::read_to_string(fixture("malm_slide.gcode")).expect("fixture must exist");
+    let cmds = parse_all(&text).expect("must parse");
+    let result = gcode_sentinel::dialect::detect_dialect(
+        &cmds,
+        Some(gcode_sentinel::dialect::SlicerDialect::PrusaSlicer),
+    );
+    // W005 should be suppressed for explicit overrides
+    assert!(result.diagnostics.iter().all(|d| d.code != "W005"));
+    // But I004 should still fire
+    assert!(result.diagnostics.iter().any(|d| d.code == "I004"));
+}
+
+// ── Time estimate extraction via detect_dialect ─────────────────────────────
+
+#[test]
+fn detect_dialect_malm_slide_extracts_estimated_time() {
+    let text = fs::read_to_string(fixture("malm_slide.gcode")).expect("fixture must exist");
+    let cmds = parse_all(&text).expect("must parse");
+    let result = gcode_sentinel::dialect::detect_dialect(&cmds, None);
+    assert!(
+        result.metadata.estimated_time_seconds.is_some(),
+        "OrcaSlicer fixture must have an estimated time"
+    );
+    let time = result.metadata.estimated_time_seconds.unwrap();
+    assert!(time > 0.0, "estimated time must be positive, got {time}");
+}
+
+#[test]
+fn detect_dialect_rose_extracts_estimated_time() {
+    let text = fs::read_to_string(fixture("rose.gcode")).expect("fixture must exist");
+    let cmds = parse_all(&text).expect("must parse");
+    let result = gcode_sentinel::dialect::detect_dialect(&cmds, None);
+    assert!(
+        result.metadata.estimated_time_seconds.is_some(),
+        "OrcaSlicer fixture must have an estimated time"
+    );
+    let time = result.metadata.estimated_time_seconds.unwrap();
+    assert!(time > 0.0, "estimated time must be positive, got {time}");
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -259,6 +259,7 @@ fn json_report_valid() {
         stats: analysis.stats,
         changes: opt.changes,
         dry_run: false,
+        slicer: None,
     };
 
     let json_str = serde_json::to_string(&report).expect("must serialize to JSON");
@@ -696,4 +697,52 @@ fn arc_fit_preserves_extrusion_on_existing_fixtures() {
             diff.new_errors
         );
     }
+}
+
+// ── Dialect detection ───────────────────────────────────────────────────────
+
+#[test]
+fn detect_dialect_malm_slide_is_orcaslicer() {
+    let text = fs::read_to_string(fixture("malm_slide.gcode"))
+        .expect("fixture malm_slide.gcode must exist");
+    let cmds = parse_all(&text).expect("malm_slide.gcode must parse");
+
+    let result = gcode_sentinel::dialect::detect_dialect(&cmds, None);
+    assert_eq!(
+        result.metadata.dialect,
+        gcode_sentinel::dialect::SlicerDialect::OrcaSlicer
+    );
+    assert_eq!(
+        result.metadata.confidence,
+        gcode_sentinel::dialect::Confidence::High
+    );
+    assert!(
+        result.metadata.slicer_version.is_some(),
+        "OrcaSlicer version should be extracted"
+    );
+    assert_eq!(result.metadata.nozzle_diameter_mm, Some(0.4));
+    assert_eq!(result.metadata.layer_height_mm, Some(0.2));
+    assert_eq!(result.metadata.filament_type.as_deref(), Some("PLA"));
+    assert_eq!(result.metadata.bed_temperature, Some(55.0));
+    assert_eq!(result.metadata.hotend_temperature, Some(210.0));
+    assert!(
+        result.metadata.estimated_time_seconds.is_some(),
+        "estimated time should be extracted"
+    );
+}
+
+#[test]
+fn detect_dialect_rose_is_orcaslicer() {
+    let text = fs::read_to_string(fixture("rose.gcode")).expect("fixture rose.gcode must exist");
+    let cmds = parse_all(&text).expect("rose.gcode must parse");
+
+    let result = gcode_sentinel::dialect::detect_dialect(&cmds, None);
+    assert_eq!(
+        result.metadata.dialect,
+        gcode_sentinel::dialect::SlicerDialect::OrcaSlicer
+    );
+    assert_eq!(
+        result.metadata.confidence,
+        gcode_sentinel::dialect::Confidence::High
+    );
 }

--- a/tests/property.rs
+++ b/tests/property.rs
@@ -1,0 +1,154 @@
+//! Property-based tests using proptest.
+
+use std::borrow::Cow;
+
+use proptest::prelude::*;
+
+use gcode_sentinel::analyzer::analyze;
+use gcode_sentinel::dialect::{detect_dialect, Confidence};
+use gcode_sentinel::models::{GCodeCommand, Spanned};
+use gcode_sentinel::optimizer::{optimize, OptConfig};
+
+/// Generate a finite f64 in a range (no NaN, no Infinity).
+fn finite_f64(min: i64, max: i64) -> impl Strategy<Value = f64> {
+    (min..=max).prop_map(|i| i as f64 / 100.0)
+}
+
+fn coord() -> impl Strategy<Value = f64> {
+    finite_f64(0, 30000) // 0.0 – 300.0 mm
+}
+
+fn feedrate() -> impl Strategy<Value = f64> {
+    finite_f64(10000, 1000000) // 100.0 – 10000.0 mm/min
+}
+
+fn e_value() -> impl Strategy<Value = f64> {
+    finite_f64(-500, 5000) // -5.0 – 50.0 mm
+}
+
+fn arb_command() -> impl Strategy<Value = GCodeCommand<'static>> {
+    prop_oneof![
+        (
+            prop::option::of(coord()),
+            prop::option::of(coord()),
+            prop::option::of(coord()),
+            prop::option::of(feedrate()),
+        )
+            .prop_map(|(x, y, z, f)| GCodeCommand::RapidMove { x, y, z, f }),
+        (
+            prop::option::of(coord()),
+            prop::option::of(coord()),
+            prop::option::of(coord()),
+            prop::option::of(e_value()),
+            prop::option::of(feedrate()),
+        )
+            .prop_map(|(x, y, z, e, f)| GCodeCommand::LinearMove { x, y, z, e, f }),
+        Just(GCodeCommand::SetAbsolute),
+        Just(GCodeCommand::SetRelative),
+        Just(GCodeCommand::Comment {
+            text: Cow::Borrowed(" random test comment"),
+        }),
+        finite_f64(18000, 26000).prop_map(|t| GCodeCommand::MetaCommand {
+            code: 104,
+            params: Cow::Owned(format!("S{t}")),
+        }),
+    ]
+}
+
+fn arb_command_sequence() -> impl Strategy<Value = Vec<Spanned<GCodeCommand<'static>>>> {
+    prop::collection::vec(arb_command(), 1..50).prop_map(|cmds| {
+        let mut result = vec![Spanned {
+            inner: GCodeCommand::SetAbsolute,
+            line: 1,
+            byte_offset: 0,
+        }];
+        for (i, cmd) in cmds.into_iter().enumerate() {
+            result.push(Spanned {
+                inner: cmd,
+                line: (i + 2) as u32,
+                byte_offset: 0,
+            });
+        }
+        result
+    })
+}
+
+proptest! {
+    #[test]
+    fn prop_extrusion_preserved_after_optimize(commands in arb_command_sequence()) {
+        let pre = analyze(commands.iter(), None);
+        let config = OptConfig::default();
+        let opt_result = optimize(commands, &config);
+        let post = analyze(opt_result.commands.iter(), None);
+        let diff = (pre.stats.total_filament_mm - post.stats.total_filament_mm).abs();
+        prop_assert!(
+            diff < 1e-6,
+            "Filament changed by {diff}: {:.6} -> {:.6}",
+            pre.stats.total_filament_mm,
+            post.stats.total_filament_mm
+        );
+    }
+
+    #[test]
+    fn prop_optimizer_converges(commands in arb_command_sequence()) {
+        let config = OptConfig::default();
+        let mut current = commands;
+        // The optimizer must converge within a bounded number of passes.
+        for pass in 0..10 {
+            let result = optimize(current, &config);
+            if result.changes.is_empty() {
+                // Converged — property holds.
+                return Ok(());
+            }
+            current = result.commands;
+            prop_assert!(
+                pass < 9,
+                "Optimizer did not converge after 10 passes"
+            );
+        }
+    }
+
+    #[test]
+    fn prop_mode_state_consistency_after_optimize(commands in arb_command_sequence()) {
+        let config = OptConfig::default();
+        let result = optimize(commands, &config);
+        let mut is_absolute = true;
+        for cmd in &result.commands {
+            match &cmd.inner {
+                GCodeCommand::SetAbsolute => is_absolute = true,
+                GCodeCommand::SetRelative => is_absolute = false,
+                GCodeCommand::LinearMove { x, y, z, .. }
+                | GCodeCommand::RapidMove { x, y, z, .. } => {
+                    if is_absolute {
+                        if let Some(xv) = x { prop_assert!(*xv >= 0.0, "negative X in absolute mode at line {}", cmd.line); }
+                        if let Some(yv) = y { prop_assert!(*yv >= 0.0, "negative Y in absolute mode at line {}", cmd.line); }
+                        if let Some(zv) = z { prop_assert!(*zv >= 0.0, "negative Z in absolute mode at line {}", cmd.line); }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    #[test]
+    fn prop_dialect_returns_unknown_for_random_commands(commands in arb_command_sequence()) {
+        let result = detect_dialect(&commands, None);
+        prop_assert_eq!(
+            result.metadata.dialect,
+            gcode_sentinel::dialect::SlicerDialect::Unknown,
+            "Expected Unknown dialect for random commands, got {:?}",
+            result.metadata.dialect
+        );
+        prop_assert_eq!(result.metadata.confidence, Confidence::None);
+    }
+
+    #[test]
+    fn prop_dialect_detection_is_deterministic(commands in arb_command_sequence()) {
+        let r1 = detect_dialect(&commands, None);
+        let r2 = detect_dialect(&commands, None);
+        prop_assert_eq!(r1.metadata.dialect, r2.metadata.dialect);
+        prop_assert_eq!(r1.metadata.confidence, r2.metadata.confidence);
+        prop_assert_eq!(r1.metadata.slicer_version, r2.metadata.slicer_version);
+        prop_assert_eq!(r1.metadata.nozzle_diameter_mm, r2.metadata.nozzle_diameter_mm);
+    }
+}


### PR DESCRIPTION
## Summary

- **#8**: Slicer dialect detection and metadata extraction for OrcaSlicer, PrusaSlicer, and Cura. Two-phase detection (comment signatures + M-code heuristics), `--dialect` CLI override, JSON/text report integration, W005/W006/W007 diagnostics.
- **#16**: Four cargo-fuzz targets (parse, round-trip, optimizer, dialect) with CI workflow on main merges (60s/target).
- **#17**: Five proptest property-based tests (extrusion preservation, optimizer convergence, mode state consistency, dialect confidence bounds, detection determinism).

## Test plan

- [x] 274 tests passing (235 unit + 29 integration + 5 property + 5 doc-tests)
- [x] Clippy pedantic clean
- [x] rustfmt clean
- [x] JSON report verified: `slicer` section with all metadata fields extracted from OrcaSlicer fixture
- [x] `--dialect` override verified: suppresses W005, forces dialect
- [x] Reviewed by 4 specialized agents (code, types, tests, error handling) — all findings addressed