### PR TITLE
fix(ci): remove trailing comma flagged by nightly clippy

### DIFF
--- a/src/dialect.rs
+++ b/src/dialect.rs
@@ -228,7 +228,7 @@ pub fn detect_dialect(
             severity: Severity::Info,
             line: detection_line,
             code: "I004",
-            message: format!("slicer dialect detected: {dialect:?} (confidence: {confidence:?})",),
+            message: format!("slicer dialect detected: {dialect:?} (confidence: {confidence:?})"),
         });
     }
 


### PR DESCRIPTION
## Summary
- Removes a trailing comma in `format!()` macro in `src/dialect.rs:231` that triggers the new `clippy::unnecessary_trailing_comma` lint on nightly
- Fixes CI failures on both nightly matrix jobs (ubuntu + windows) after merging PR #24

## Test plan
- [x] `cargo clippy -- -D warnings` passes locally
- CI nightly jobs should go green